### PR TITLE
stop waking up every 1ms for polling and do regular frame scheduling

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -93,10 +93,6 @@ impl ObjectBimapExt for ObjectBimap {
     }
 }
 
-pub struct CalloopData {
-    pub state: WprsClientState,
-}
-
 pub struct ClientOptions {
     pub title_prefix: String,
 }

--- a/src/compositor_utils.rs
+++ b/src/compositor_utils.rs
@@ -54,7 +54,7 @@ where
 
 // Based on https://github.com/Smithay/smithay/blob/b1c682742ac7b9fa08736476df3e651489709ac2/src/desktop/wayland/utils.rs.
 #[derive(Debug, Default)]
-struct SurfaceFrameThrottlingState(Mutex<Option<Duration>>);
+pub(crate) struct SurfaceFrameThrottlingState(Mutex<Option<Duration>>);
 
 impl SurfaceFrameThrottlingState {
     pub fn update(&self, time: Duration, throttle: Duration) -> bool {

--- a/src/serialization/wayland.rs
+++ b/src/serialization/wayland.rs
@@ -216,16 +216,9 @@ impl Buffer {
         let self_data = match Arc::get_mut(&mut self.data) {
             Some(self_data) => self_data,
             None => {
-                // TODO: this happens more frequently than we'd like. This seems
-                // to happen when a callback is sent shortly after a commit and
-                // then the client immediately commits again (as is its right).
-                // Sending callbacks is currently done on a timer, not related
-                // to commits. We used to send it right after a commit, but we
-                // didn't have a good way to throttle them there. Ideally we'd
-                // send them on a timer but delay sending them for specific
-                // surfaces if that surface's last commit is still being
-                // processed. Also change the log line to a warning after we fix
-                // this.
+                // TODO: this happens rarely but still more frequently than we'd
+                // like. Figure out why. Also change the log line to a warning
+                // after we fix this.
                 debug!("Next commit received for surface before serialization of previous commit finished.");
                 self.data = Arc::new(Vec4u8s::with_total_size(data.len()));
                 // We just created the Arc, no one else can have a copy of it

--- a/src/xwayland_xdg_shell/mod.rs
+++ b/src/xwayland_xdg_shell/mod.rs
@@ -23,7 +23,6 @@ use smithay::output::Output;
 use smithay::reexports::calloop::LoopHandle;
 use smithay::reexports::wayland_server::backend::ObjectId as CompositorObjectId;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface as CompositorWlSurface;
-use smithay::reexports::wayland_server::Display;
 use smithay::reexports::wayland_server::DisplayHandle;
 use smithay::reexports::wayland_server::Resource;
 use smithay::utils::Serial;
@@ -219,7 +218,7 @@ impl WaylandSurface for XWaylandSurface {
 #[derive(Debug)]
 pub struct WprsState {
     pub dh: DisplayHandle,
-    pub event_loop_handle: LoopHandle<'static, CalloopData>,
+    pub event_loop_handle: LoopHandle<'static, Self>,
     pub client_state: WprsClientState,
     pub compositor_state: WprsCompositorState,
     pub surface_bimap: BiMap<CompositorObjectId, ClientObjectId>,
@@ -233,7 +232,7 @@ impl WprsState {
         globals: &GlobalList,
         qh: QueueHandle<Self>,
         conn: Connection,
-        event_loop_handle: LoopHandle<'static, CalloopData>,
+        event_loop_handle: LoopHandle<'static, Self>,
         decoration_behavior: DecorationBehavior,
     ) -> Result<Self> {
         Ok(Self {
@@ -356,10 +355,4 @@ pub fn xsurface_from_x11_surface<'a>(
             .map(|s| s == surface)
             .unwrap_or(false)
     })
-}
-
-pub struct CalloopData {
-    pub state: WprsState,
-    pub display: Display<WprsState>,
-    pub globals: GlobalList,
 }


### PR DESCRIPTION
Actually schedule frame callbacks the right way by scheduling the callback to be completed a frame interval after the current commit, less a couple ms for processing time.

Also stop processing buffers for sync subsurfaces twice.