### PR TITLE
fix attach crash

### DIFF
--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -474,6 +474,13 @@ impl RemoteSurface {
                 }
                 // else use the data in new_buffer as the buffer is data is
                 // still sent inline on connection.
+
+                if new_buffer.data.is_empty() {
+                    // TODO: do we want to log a warning and let the rest of the
+                    // commit work? Unclear that it matters.
+                    return Err(anyhow!("Received buffer commit with empty data. This can if wprsc reattaches between wprsd sending a buffer message and a commit message."));
+                }
+
                 self.set_buffer(new_buffer, pool).location(loc!())?;
             },
             Some(BufferAssignment::Removed) => {


### PR DESCRIPTION
If we happen to reattach right between when a server sends a buffer and when it sends the commit message, the buffer size in the commit message will be 0 and we should ignore it. The odds of this happening are actually not bad since buffer and commit messages are the vast majority of the messages sent and sending a buffer takes a few ms, a decent percentage of the time between frames.