### PR TITLE
remove deprecated fields from deny.toml

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,18 +1,16 @@
+[graph]
 all-features = true
 
 [advisories]
+version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
-vulnerability = "deny"
-unmaintained = "deny"
 yanked = "deny"
-notice = "deny"
 ignore = [
     #"RUSTSEC-0000-0000",
 ]
 
 [licenses]
-unlicensed = "deny"
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
@@ -24,9 +22,6 @@ allow = [
     "Unicode-DFS-2016",
     "Zlib",
 ]
-copyleft = "deny"
-allow-osi-fsf-free = "neither"
-default = "deny"
 confidence-threshold = 1.0
 
 [bans]


### PR DESCRIPTION
See https://github.com/EmbarkStudios/cargo-deny/pull/611 for details.