### PR TITLE
bug fix: wait for initial subsurface frame callback before attaching buffer

### DIFF
--- a/src/xwayland_xdg_shell/mod.rs
+++ b/src/xwayland_xdg_shell/mod.rs
@@ -123,6 +123,7 @@ impl XWaylandSurface {
         match &self.role {
             Some(Role::XdgToplevel(toplevel)) if !toplevel.configured => false,
             Some(Role::XdgPopup(popup)) if !popup.configured => false,
+            Some(Role::SubSurface(subsurface)) if !subsurface.position_initialized => false,
             _ => self.x11_surface.is_some() || matches!(self.role, Some(Role::Cursor)),
         }
     }


### PR DESCRIPTION
If we attach buffer before the frame callback, the subsurface may briefly show up at the wrong spot until the compositor moves it.