### PR TITLE
Add buffer attach while waiting for inistial subsurface frame callback

### DIFF
--- a/src/xwayland_xdg_shell/client.rs
+++ b/src/xwayland_xdg_shell/client.rs
@@ -1353,7 +1353,7 @@ impl XWaylandSubSurface {
                 .subsurface
                 .set_position(x + self.parent_offset.x, y + self.parent_offset.y);
             local_wl_surface.frame(qh, local_wl_surface.clone());
-            local_wl_surface.commit();
+            local_wl_surface.commit(); // TODO
             self.parent_surface.commit();
 
             self.pending_frame_callback = true;

--- a/src/xwayland_xdg_shell/compositor.rs
+++ b/src/xwayland_xdg_shell/compositor.rs
@@ -474,7 +474,7 @@ pub fn commit_inner(
         }
     }
 
-    if xwayland_surface.ready() {
+    if xwayland_surface.ready() || xwayland_surface.needs_position() {
         if let Some(Role::SubSurface(subsurface)) = &mut xwayland_surface.role {
             if !subsurface.pending_frame_callback {
                 xwayland_surface.frame(&state.client_state.qh);

--- a/src/xwayland_xdg_shell/mod.rs
+++ b/src/xwayland_xdg_shell/mod.rs
@@ -136,6 +136,15 @@ impl XWaylandSurface {
         }
     }
 
+    // We won't receive frame callbacks (depending on the compositor) if the surface isn't visible,
+    // i.e. has a buffer attached.
+    fn needs_position(&self) -> bool {
+        if let Some(Role::SubSurface(subsurface)) = &self.role {
+            return !subsurface.position_initialized;
+        }
+        false
+    }
+
     fn try_attach_buffer(&mut self, qh: &QueueHandle<WprsState>) {
         if !self.buffer_attached {
             if let Some(buffer) = &self.buffer {


### PR DESCRIPTION
Weirdly, this only seems to affect directly running xwayland-xdg-shell, and not wprsd/wprsc.  Which seems bad because that might mean the attach is leaking before the frame callback, and that the position isn't getting initialized properly? 