### PR TITLE
combine buffer attaches and subsurface positions into the same commit

### DIFF
--- a/src/client/subsurface.rs
+++ b/src/client/subsurface.rs
@@ -264,6 +264,10 @@ impl RemoteSubSurface {
             .location(loc!())?
             .as_sub_surface_mut()
             .location(loc!())?;
+
+        role.local_subsurface
+            .set_position(subsurface_state.location.x, subsurface_state.location.y);
+
         if role.sync == subsurface_state.sync {
             return Ok(());
         }

--- a/src/serialization/wayland.rs
+++ b/src/serialization/wayland.rs
@@ -498,7 +498,7 @@ impl PointerEvent {
 #[archive_attr(derive(bytecheck::CheckBytes, Debug))]
 pub struct SubSurfaceState {
     pub parent: WlSurfaceId,
-    pub position: Point<i32>,
+    pub location: Point<i32>,
     pub sync: bool,
 }
 
@@ -506,7 +506,7 @@ impl SubSurfaceState {
     pub fn new(parent: &WlSurface) -> Self {
         Self {
             parent: WlSurfaceId::new(parent),
-            position: (0, 0).into(),
+            location: (0, 0).into(),
             sync: true,
         }
     }

--- a/src/server/smithay_handlers.rs
+++ b/src/server/smithay_handlers.rs
@@ -746,6 +746,11 @@ pub fn commit_impl(
         Some(Role::Cursor(_)) => {},
         Some(Role::SubSurface(subsurface_state)) => {
             subsurface_state.sync = sync;
+            subsurface_state.location = surface_data
+                .cached_state
+                .pending::<SubsurfaceCachedState>()
+                .location
+                .into();
         },
         Some(Role::XdgToplevel(toplevel_state)) => {
             set_xdg_toplevel_attributes(surface_data, toplevel_state).location(loc!())?;

--- a/src/xwayland_xdg_shell/compositor.rs
+++ b/src/xwayland_xdg_shell/compositor.rs
@@ -483,7 +483,7 @@ pub fn commit_inner(
             xwayland_surface.frame(&state.client_state.qh);
         }
 
-        xwayland_surface.try_attach_buffer(&state.client_state.qh);
+        xwayland_surface.try_attach_buffer();
     }
 
     if xwayland_surface.ready() || xwayland_surface.needs_configure() {


### PR DESCRIPTION
previously, our plan was to do a subsurface set position and then wat for the frame callback to attach the bufferfor a new x11 subsurface. This doesn't work, since compositors will only perform frame callbacks to surfaces with attached buffers.