### PR TITLE
Expand Xwayland screen size

### DIFF
--- a/src/xwayland_xdg_shell/xwayland.rs
+++ b/src/xwayland_xdg_shell/xwayland.rs
@@ -41,6 +41,7 @@ impl XwmHandler for WprsState {
     }
 
     fn new_window(&mut self, _xwm: XwmId, _window: X11Surface) {}
+
     fn new_override_redirect_window(&mut self, _xwm: XwmId, _window: X11Surface) {}
 
     fn map_window_request(&mut self, _xwm: XwmId, window: X11Surface) {


### PR DESCRIPTION
Right now there isn't a way to handle events wayland events that
move beyond the bounds of the xwayland screen.  E.g. mouse events
outside the bounds of the wayland surface will hit the screen bounds
when passed to x11.  So let's make the xwayland screen bigger
so that we have some buffer to work with.