### PR TITLE
Handle getting toplevel messages before commits edge case

### DIFF
--- a/src/client/server_handlers.rs
+++ b/src/client/server_handlers.rs
@@ -232,60 +232,35 @@ impl WprsClientState {
             warn!("received request for unknown surface");
             return Ok(());
         };
-        match request.payload {
-            ToplevelRequestPayload::Destroyed => {
-                surface.role = None;
-            },
-            ToplevelRequestPayload::SetMaximized => {
-                surface
-                    .xdg_toplevel()
-                    .location(loc!())?
-                    .local_window
-                    .set_maximized();
-            },
-            ToplevelRequestPayload::UnsetMaximized => {
-                surface
-                    .xdg_toplevel()
-                    .location(loc!())?
-                    .local_window
-                    .unset_maximized();
-            },
-            ToplevelRequestPayload::SetFullscreen => {
-                surface
-                    .xdg_toplevel()
-                    .location(loc!())?
-                    .local_window
-                    .set_fullscreen(None);
-            },
-            ToplevelRequestPayload::UnsetFullscreen => {
-                surface
-                    .xdg_toplevel()
-                    .location(loc!())?
-                    .local_window
-                    .unset_fullscreen();
-            },
-            ToplevelRequestPayload::SetMinimized => {
-                surface
-                    .xdg_toplevel()
-                    .location(loc!())?
-                    .local_window
-                    .set_minimized();
-            },
-            ToplevelRequestPayload::Move(xdg_shell::Move { serial }) => {
-                surface
-                    .xdg_toplevel()
-                    .location(loc!())?
-                    .local_window
-                    .xdg_toplevel()
-                    ._move(&self.seat_state.seats().next().location(loc!())?, serial);
-            },
-            ToplevelRequestPayload::Resize(xdg_shell::Resize { serial, edge }) => {
-                surface
-                    .xdg_toplevel()
-                    .location(loc!())?
-                    .local_window
-                    .xdg_toplevel()
-                    .resize(
+
+        if let Some(Role::XdgToplevel(toplevel)) = &surface.role {
+            match request.payload {
+                ToplevelRequestPayload::Destroyed => {
+                    surface.role = None;
+                },
+                ToplevelRequestPayload::SetMaximized => {
+                    toplevel.local_window.set_maximized();
+                },
+                ToplevelRequestPayload::UnsetMaximized => {
+                    toplevel.local_window.unset_maximized();
+                },
+                ToplevelRequestPayload::SetFullscreen => {
+                    toplevel.local_window.set_fullscreen(None);
+                },
+                ToplevelRequestPayload::UnsetFullscreen => {
+                    toplevel.local_window.unset_fullscreen();
+                },
+                ToplevelRequestPayload::SetMinimized => {
+                    toplevel.local_window.set_minimized();
+                },
+                ToplevelRequestPayload::Move(xdg_shell::Move { serial }) => {
+                    toplevel
+                        .local_window
+                        .xdg_toplevel()
+                        ._move(&self.seat_state.seats().next().location(loc!())?, serial);
+                },
+                ToplevelRequestPayload::Resize(xdg_shell::Resize { serial, edge }) => {
+                    toplevel.local_window.xdg_toplevel().resize(
                         &self.seat_state.seats().next().location(loc!())?,
                         serial,
                         // The error type is (). :(
@@ -293,7 +268,8 @@ impl WprsClientState {
                             .map_err(|_| anyhow!("invalid edge"))
                             .location(loc!())?,
                     );
-            },
+                },
+            }
         }
         Ok(())
     }

--- a/src/client/xdg_shell.rs
+++ b/src/client/xdg_shell.rs
@@ -95,6 +95,22 @@ impl RemoteXdgToplevel {
                         .local_window,
                 ));
             }
+
+            if let Some(maximized) = toplevel_state.maximized {
+                if maximized {
+                    local_window.set_maximized();
+                } else {
+                    local_window.unset_maximized();
+                }
+            }
+
+            if let Some(fullscreen) = toplevel_state.fullscreen {
+                if fullscreen {
+                    local_window.set_fullscreen(None);
+                } else {
+                    local_window.unset_fullscreen();
+                }
+            }
         }
 
         object_bimap.insert(

--- a/src/serialization/xdg_shell.rs
+++ b/src/serialization/xdg_shell.rs
@@ -213,6 +213,8 @@ pub struct XdgToplevelState {
     pub title: Option<String>,
     pub app_id: Option<String>,
     pub decoration_mode: Option<DecorationMode>,
+    pub maximized: Option<bool>,
+    pub fullscreen: Option<bool>,
 }
 
 impl XdgToplevelState {
@@ -223,6 +225,8 @@ impl XdgToplevelState {
             title: None,
             app_id: None,
             decoration_mode: None,
+            maximized: None,
+            fullscreen: None,
         }
     }
 }


### PR DESCRIPTION
Right now, VSCode will send an unmaximize toplevel request in it's initial commit.  Because we don't buffer these requests, wprsc will process it before the inital commit and error out.