### PR TITLE
fix ignored log_file in config files

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -207,7 +207,7 @@ pub fn file_log_level() -> impl Parser<Option<SerializableLevel>> {
         .optional()
 }
 
-pub fn log_file() -> impl Parser<Option<PathBuf>> {
+pub fn log_file() -> impl Parser<Option<Option<PathBuf>>> {
     // let argv0 = PathBuf::from(env::args().next().unwrap());
     // let argv0_basename = Path::new(argv0.components().last().unwrap().as_os_str());
     // let tmp_dir = env::temp_dir();
@@ -216,6 +216,7 @@ pub fn log_file() -> impl Parser<Option<PathBuf>> {
     bpaf::long("log-file")
         .argument::<PathBuf>("PATH")
         .optional()
+        .map(|log_file| log_file.map(Some))
 }
 
 pub fn framerate() -> impl Parser<Option<u32>> {

--- a/src/bin/wprsc.rs
+++ b/src/bin/wprsc.rs
@@ -50,6 +50,8 @@ pub struct WprscConfig {
     config_file: PathBuf,
     pub socket: PathBuf,
     pub control_socket: PathBuf,
+    // Optional fields don't get wrapped unless we specify it ourselves
+    #[optional_wrap]
     pub log_file: Option<PathBuf>,
     pub stderr_log_level: SerializableLevel,
     pub file_log_level: SerializableLevel,

--- a/src/bin/wprsd.rs
+++ b/src/bin/wprsd.rs
@@ -54,6 +54,8 @@ pub struct WprsdConfig {
     wayland_display: String,
     socket: PathBuf,
     framerate: u32,
+    // Optional fields don't get wrapped unless we specify it ourselves
+    #[optional_wrap]
     log_file: Option<PathBuf>,
     stderr_log_level: SerializableLevel,
     file_log_level: SerializableLevel,

--- a/src/bin/xwayland-xdg-shell.rs
+++ b/src/bin/xwayland-xdg-shell.rs
@@ -51,6 +51,8 @@ pub struct XwaylandXdgShellConfig {
     config_file: PathBuf,
     wayland_display: String,
     display: u32,
+    // Optional fields don't get wrapped unless we specify it ourselves
+    #[optional_wrap]
     log_file: Option<PathBuf>,
     stderr_log_level: SerializableLevel,
     file_log_level: SerializableLevel,


### PR DESCRIPTION
Options inside Config structs don't default to getting wrapped by another option.  That means the parser can't tell if the struct was initialized to None or was missing.  So specify that we want to wrap log_file with another option so it can be properly differentiated.