### PR TITLE
fix broken keycodes being offset by 8

### DIFF
--- a/src/server/client_handlers.rs
+++ b/src/server/client_handlers.rs
@@ -257,7 +257,9 @@ impl WprsServerState {
 
         keyboard.input::<(), _>(
             self,
-            keycode.into(),
+            // our keycode is getting offset by 8 for reasons
+            // see https://github.com/Smithay/smithay/pull/1536
+            (keycode + 8).into(),
             state,
             serial,
             self.start_time.elapsed().as_millis() as u32,

--- a/src/xwayland_xdg_shell/mod.rs
+++ b/src/xwayland_xdg_shell/mod.rs
@@ -435,7 +435,9 @@ impl WprsState {
 
         keyboard.input::<(), _>(
             self,
-            keycode.into(),
+            // our keycode is getting offset by 8 for reasons
+            // see https://github.com/Smithay/smithay/pull/1536
+            (keycode + 8).into(),
             state,
             serial,
             self.compositor_state.start_time.elapsed().as_millis() as u32,


### PR DESCRIPTION
see https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h for all the keycodes

I don't think we have to worry about overflowing the u32.