### PR TITLE
Dockerfile build of deb install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG BASE_IMAGE=debian:trixie
+
+FROM ${BASE_IMAGE}
+
+RUN apt update && \ 
+    apt install -y curl libxkbcommon-dev libwayland-dev devscripts pkg-config
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+ENV PATH="$PATH:/root/.cargo/bin"
+
+COPY / /wprs
+WORKDIR /wprs
+
+RUN dpkg-buildpackage --sanitize-env -us -uc -b -d -rfakeroot
+
+WORKDIR /
+
+RUN echo "Deb Files Created:" && ls *.deb

--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ The launcher (`wprs`) requires:
 This requires cargo and a rustc matching the one in rust-toolchain.toml to be
 installed. The debian rustc package is not used due to being too old.
 
+### Docker
+
+To build .deb files without installing the above dependencies, we supply a `Dockerfile`.
+
+To build the .deb and copy it locally:
+
+```shell
+docker build . -t wprs
+docker run --user $(id -u):$(id -g)  -v $(pwd):/deb --rm wprs:latest bash -c "cp *.deb /deb/"
+```
+
+By default, the `Dockerfile `builds against `debian:trixie` but you can use the `ARG`
+`BASE_IMAGE` to overwrite this to another distribution and/or release version.
+
+For example:
+
+```shell
+docker build --build-arg BASE_IMAGE=ubuntu . -t wprs
+```
 
 ## Usage
 


### PR DESCRIPTION
This makes it easier to generate an installation .deb for any Debian based system through a Dockerfile, without having to locally install the required dependencies.

This could potentially be used later on as a CI build step.