### PR TITLE
Add notification forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,145 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1237c0ae75a0f3765f58910ff9cdd0a12eeb39ab2f4c7de23262f337f0aacbb3"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.7",
+ "slab",
+ "tracing",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde3f4e40e6021d7acffc90095cbd6dc54cb593903d1de5832f435eb274b85dc"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.0.7",
+ "tracing",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7605a4e50d4b06df3898d5a70bf5fde51ed9059b0434b73105193bc27acce0d"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.7",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.88"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,6 +260,19 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -196,8 +348,10 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10929724661d1c43856fd87c7a127ae944ec55579134fb485e4136fb6a46fdcb"
 dependencies = [
+ "async-task",
  "bitflags 2.9.0",
- "nix",
+ "nix 0.29.0",
+ "pin-utils",
  "polling",
  "rustix 0.38.44",
  "slab",
@@ -453,12 +607,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
 dependencies = [
  "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "enumflags2"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2f4b465f5318854c6f8dd686ede6c0a9dc67d4b1ac241cf0eb51521a309147"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4caf64a58d7a6d65ab00639b046ff54399a39f5f2554728895ace4b297cd79"
+dependencies = [
  "proc-macro2",
  "quote",
  "syn",
@@ -478,6 +659,27 @@ checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -516,6 +718,49 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "pin-utils",
+]
 
 [[package]]
 name = "generator"
@@ -608,6 +853,12 @@ name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "home"
@@ -845,6 +1096,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -928,10 +1192,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -961,6 +1241,23 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
 
 [[package]]
 name = "pkg-config"
@@ -1327,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.5"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
@@ -1416,6 +1713,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_spanned"
 version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1438,6 +1746,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -1580,7 +1897,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.2",
  "once_cell",
- "rustix 1.0.5",
+ "rustix 1.0.7",
  "windows-sys",
 ]
 
@@ -1801,6 +2118,17 @@ dependencies = [
  "target-triple",
  "termcolor",
  "toml",
+]
+
+[[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "winapi",
 ]
 
 [[package]]
@@ -2315,6 +2643,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arrayref",
+ "async-io",
+ "async-lock",
  "bimap",
  "bpaf",
  "bytemuck",
@@ -2324,11 +2654,12 @@ dependencies = [
  "divbuf",
  "enum-as-inner",
  "fallible-iterator",
+ "futures-util",
  "home",
  "itertools 0.13.0",
  "lagoon",
  "merkle_hash",
- "nix",
+ "nix 0.29.0",
  "num_enum",
  "optional_struct",
  "png",
@@ -2338,6 +2669,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serde_repr",
  "smithay",
  "smithay-client-toolkit",
  "static_assertions",
@@ -2349,6 +2681,7 @@ dependencies = [
  "trybuild",
  "whoami",
  "x11rb",
+ "zbus",
  "zstd",
 ]
 
@@ -2407,6 +2740,66 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a7c7cee313d044fca3f48fa782cb750c79e4ca76ba7bc7718cd4024cdf6f68"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "nix 0.30.1",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "windows-sys",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a17e7e5eec1550f747e71a058df81a9a83813ba0f6a95f39c4e218bdc7ba366a"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2452,4 +2845,45 @@ checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d30786f75e393ee63a21de4f9074d4c038d52c5b1bb4471f955db249f9dffb1"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75fda702cd42d735ccd48117b1630432219c0e9616bf6cb0f8350844ee4d9580"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e16edfee43e5d7b553b77872d99bc36afdda75c223ca7ad5e3fbecd82ca5fc34"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "static_assertions",
+ "syn",
+ "winnow",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ ron = "0.8.1"
 serde = "1.0.203"
 serde_derive = "1.0.203"
 serde_json = "1.0.117"
-calloop = { version = "0.14.2", features = ["signals"] }
+calloop = { version = "0.14.2", features = ["executor", "block_on", "signals"] }
 smithay = { git = "https://github.com/Smithay/smithay.git", default-features = false, features = [
     "desktop",
     "xwayland",
@@ -58,6 +58,11 @@ tracy-client = { version = "0.17.0", optional = true, features = [
 whoami = "1.5.1"
 x11rb = "0.13.1"
 zstd = { version = "0.13.1" }
+zbus = { version = "5.7.0", default-features = false, features = ["async-io"] }
+serde_repr = "0.1.20"
+async-io = "2.4.1"
+async-lock = { version = "3.4.0", default-features = false }
+futures-util = { version = "0.3.31", default-features = false }
 
 [build-dependencies]
 merkle_hash = "3.6.1"

--- a/src/client/notification_handlers.rs
+++ b/src/client/notification_handlers.rs
@@ -1,0 +1,50 @@
+use tracing::{error, instrument};
+
+use crate::{
+    dbus::NotificationSignals,
+    serialization::{Event, NotificationEvents, SendType},
+};
+
+use super::WprsClientState;
+
+impl WprsClientState {
+    #[instrument(skip(self), level = "debug")]
+    pub fn handle_notification_signal(&mut self, signal: NotificationSignals) {
+        let notification_id_mapper = self.notification_id_mapper.clone();
+        let event_writer = self.serializer.writer().clone().into_inner();
+        match signal {
+            NotificationSignals::Close(local_notification_id) => {
+                if let Err(err) = self.notification_scheduler.schedule(async move {
+                    let notification_mapper = notification_id_mapper.lock().await;
+                    if let Some(remote_notification_id) =
+                        notification_mapper.get(&local_notification_id)
+                    {
+                        if let Err(err) = event_writer.send(SendType::Object(Event::Notification(
+                            NotificationEvents::Closed(*remote_notification_id),
+                        ))) {
+                            error!("failed to send notification close event: {:?}", err);
+                        };
+                    };
+                }) {
+                    error!("failed to schedule notification close handle: {:?}", err);
+                };
+            },
+            NotificationSignals::Action(local_notification_id, action_key) => {
+                if let Err(err) = self.notification_scheduler.schedule(async move {
+                    let notification_mapper = notification_id_mapper.lock().await;
+                    if let Some(remote_notification_id) =
+                        notification_mapper.get(&local_notification_id)
+                    {
+                        if let Err(err) = event_writer.send(SendType::Object(Event::Notification(
+                            NotificationEvents::ActionInvoked(*remote_notification_id, action_key),
+                        ))) {
+                            error!("failed to send notification close event: {:?}", err);
+                        };
+                    };
+                }) {
+                    error!("failed to schedule notification close handle: {:?}", err);
+                };
+            },
+        }
+    }
+}

--- a/src/dbus/mod.rs
+++ b/src/dbus/mod.rs
@@ -1,0 +1,194 @@
+use core::sync::atomic::AtomicU32;
+use core::sync::atomic::Ordering;
+use std::collections::HashMap;
+
+use crossbeam_channel::Sender;
+use serde::Deserialize;
+use serde::Serialize;
+use serde_repr::Deserialize_repr;
+use serde_repr::Serialize_repr;
+use tracing::error;
+use zbus::interface;
+use zbus::object_server::SignalEmitter;
+use zbus::zvariant::Type;
+use zbus::zvariant::Value;
+
+use crate::channel_utils::DiscardingSender;
+use crate::serialization::ForwardedNotification;
+use crate::serialization::NotificationRequests;
+use crate::serialization::Request;
+use crate::serialization::SendType;
+
+#[derive(Debug, Type, Serialize, Deserialize, Clone)]
+pub struct ServerInformation {
+    /// The product name of the server.
+    name: String,
+
+    /// The vendor name. For example "KDE," "GNOME," "freedesktop.org" or "Microsoft".
+    vendor: String,
+
+    /// The server's version number.
+    version: String,
+
+    /// The specification version the server is compliant with.
+    spec_version: String,
+}
+
+impl Default for ServerInformation {
+    fn default() -> Self {
+        Self {
+            name: String::from(env!("CARGO_CRATE_NAME")),
+            vendor: String::from(env!("CARGO_PKG_AUTHORS")),
+            version: String::from(env!("CARGO_PKG_VERSION")),
+            spec_version: String::from("1.3"),
+        }
+    }
+}
+
+pub struct Notifications {
+    server_information: ServerInformation,
+    current_id: AtomicU32,
+    sender: DiscardingSender<Sender<SendType<Request>>>,
+}
+
+impl Notifications {
+    pub fn new(sender: DiscardingSender<Sender<SendType<Request>>>) -> Self {
+        Self {
+            sender,
+            server_information: ServerInformation::default(),
+            current_id: AtomicU32::default(),
+        }
+    }
+}
+
+#[derive(Serialize_repr, Deserialize_repr, Debug, Clone, Copy, Type)]
+#[repr(u8)]
+pub(super) enum CloseReason {
+    Expired = 1,
+    UserDismissed = 2,
+    CallClose = 3,
+    Undefined = 4,
+}
+
+#[derive(Debug)]
+pub enum NotificationSignals {
+    Close(u32),
+    Action(u32, String),
+}
+
+impl TryFrom<NotificationClosed> for NotificationSignals {
+    type Error = zbus::Error;
+
+    fn try_from(value: NotificationClosed) -> std::result::Result<Self, Self::Error> {
+        let args = value.args()?;
+
+        Ok(Self::Close(args.id))
+    }
+}
+
+impl TryFrom<ActionInvoked> for NotificationSignals {
+    type Error = zbus::Error;
+
+    fn try_from(value: ActionInvoked) -> std::result::Result<Self, Self::Error> {
+        let args = value.args()?;
+
+        Ok(Self::Action(args.id, args.action_key.to_string()))
+    }
+}
+
+#[interface(
+    name = "org.freedesktop.Notifications",
+    proxy(
+        gen_blocking = false,
+        default_path = "/org/freedesktop/Notifications",
+        default_service = "org.freedesktop.Notifications",
+    )
+)]
+impl Notifications {
+    /// CloseNotification method
+    pub(super) async fn close_notification(
+        &self,
+        id: u32,
+        #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
+    ) {
+        let Err(err) = self.sender.send(SendType::Object(Request::Notification(
+            NotificationRequests::Close(id),
+        ))) else {
+            let Err(err) = emitter
+                .notification_closed(id, CloseReason::CallClose)
+                .await
+            else {
+                return;
+            };
+
+            error!("failed to emit notification close signal {:?}", err);
+            return;
+        };
+
+        error!(
+            "failed to send close notification request to client {:?}",
+            err
+        );
+    }
+
+    pub(super) fn get_capabilities(&self) -> Vec<String> {
+        vec![
+            String::from("actions"),
+            String::from("body"),
+            String::from("icon-static"),
+            String::from("persistence"),
+        ]
+    }
+
+    pub(super) fn get_server_information(&self) -> ServerInformation {
+        self.server_information.clone()
+    }
+
+    /// Notify method
+    #[allow(clippy::too_many_arguments)]
+    pub(super) fn notify(
+        &self,
+        app_name: &str,
+        replaces_id: u32,
+        app_icon: &str,
+        summary: &str,
+        body: &str,
+        actions: Vec<&str>,
+        _hints: HashMap<&str, Value<'_>>,
+        expire_timeout: i32,
+    ) -> u32 {
+        // creating an server ID for notification
+        let id = self.current_id.fetch_add(1, Ordering::AcqRel);
+
+        if let Err(err) = self.sender.send(SendType::Object(Request::Notification(
+            NotificationRequests::New(ForwardedNotification {
+                remote_id: id,
+                app_name: app_name.to_string(),
+                replaces_id,
+                app_icon: app_icon.to_string(),
+                summary: summary.to_string(),
+                body: body.to_string(),
+                actions: actions.into_iter().map(String::from).collect(),
+                expire_timeout,
+            }),
+        ))) {
+            error!("failed to forward notification to client {:?}", err);
+        };
+
+        id
+    }
+
+    #[zbus(signal)]
+    pub(super) async fn notification_closed(
+        emitter: &SignalEmitter<'_>,
+        id: u32,
+        reason: CloseReason,
+    ) -> zbus::Result<()>;
+
+    #[zbus(signal)]
+    pub(super) async fn action_invoked(
+        emitter: &SignalEmitter<'_>,
+        id: u32,
+        action_key: &str,
+    ) -> zbus::Result<()>;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub mod transpose;
 pub mod utils;
 pub mod vec4u8;
 pub mod xwayland_xdg_shell;
+pub mod dbus;
 
 #[cfg(feature = "tracy-allocator")]
 pub mod tracy_allocator;

--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -122,6 +122,31 @@ pub enum Request {
     Data(wayland::DataRequest),
     ClientDisconnected(ClientId),
     Capabilities(Capabilities),
+    Notification(NotificationRequests),
+}
+
+#[derive(Debug, Clone, PartialEq, Archive, Deserialize, Serialize)]
+pub struct ForwardedNotification {
+    pub remote_id: u32,
+    pub app_name: String,
+    pub replaces_id: u32,
+    pub app_icon: String,
+    pub summary: String,
+    pub body: String,
+    pub actions: Vec<String>,
+    pub expire_timeout: i32,
+}
+
+#[derive(Debug, Clone, PartialEq, Archive, Deserialize, Serialize)]
+pub enum NotificationRequests {
+    New(ForwardedNotification),
+    Close(u32),
+}
+
+#[derive(Debug, Clone, PartialEq, Archive, Deserialize, Serialize)]
+pub enum NotificationEvents {
+    Closed(u32),
+    ActionInvoked(u32, String),
 }
 
 #[derive(Debug, Clone, PartialEq, Archive, Deserialize, Serialize)]
@@ -134,6 +159,7 @@ pub enum Event {
     Popup(xdg_shell::PopupEvent),
     Data(wayland::DataEvent),
     Surface(wayland::SurfaceEvent),
+    Notification(NotificationEvents),
 }
 
 // TODO: test that object ids with same value from different clients hash


### PR DESCRIPTION
Add support for notification forwarding.

wprs is a great tool that I use daily. My main challenge has been with notifications, as I'd like them to be forwarded to the client.

This is my first time developing for DBus, and I've opted to use [`zbus`](https://docs.rs/zbus/latest/zbus/) for the connection. I integrated it with the existing event loop by leveraging calloop's [`executor`](https://docs.rs/calloop/latest/calloop/#asyncawait-compatibility) feature. I'm open to feedback on this approach.

I still have some improvements planned before marking this as ready, primarily regarding notification ID handling.

I'm submitting this early to get any initial feedback or suggestions.