### PR TITLE
bug fix: cap how many messages that the writer will queue

### DIFF
--- a/src/serialization/mod.rs
+++ b/src/serialization/mod.rs
@@ -146,6 +146,7 @@ pub fn hash<T: Hash>(t: &T) -> u64 {
 }
 
 const CHANNEL_SIZE: usize = 1024;
+const MESSAGE_LIMIT: usize = 128;
 
 pub trait Serializable:
     Debug
@@ -584,7 +585,7 @@ where
         let (reader_tx, reader_rx): (channel::SyncSender<RecvType<RT>>, Channel<RecvType<RT>>) =
             channel::sync_channel(CHANNEL_SIZE);
         let (writer_tx, writer_rx): (Sender<SendType<ST>>, Receiver<SendType<ST>>) =
-            crossbeam_channel::unbounded();
+            crossbeam_channel::bounded(MESSAGE_LIMIT);
         let other_end_connected = Arc::new(AtomicBool::new(false));
 
         {
@@ -611,7 +612,7 @@ where
         let (reader_tx, reader_rx): (channel::SyncSender<RecvType<RT>>, Channel<RecvType<RT>>) =
             channel::sync_channel(CHANNEL_SIZE);
         let (writer_tx, writer_rx): (Sender<SendType<ST>>, Receiver<SendType<ST>>) =
-            crossbeam_channel::unbounded();
+            crossbeam_channel::bounded(MESSAGE_LIMIT);
         let other_end_connected = Arc::new(AtomicBool::new(true));
 
         {


### PR DESCRIPTION
* With an unbounded queue size, the writer will continue to grow indefinitely.  This could mean it's possible to grow the queue faster than can be processed, depending on if wprs is writing more than the machine's network speed can handle.
* If we cap it then any `send()`calls with a capped queue should block until there is space (which should hopefully just block up wprs from doing anything).
* What would be a good capacity to use?  The queue should be taking encoded messages.  So if we use 10% compression ratio of a 1080p (1920x1080 pixels) app, the raw buffer message size should be around 1920x1080x4x(1/10)=~.83 MB.  And if only half the messages are buffer messages and half are surface state, then we could have a cap of 128 messages for 53.12 MB


TODO: need to test this to see if it actually makes a difference still, and if blocking would cause something else to break.