### PR TITLE
aarch64 support: NEON filtering pipeline

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,2 @@
-[build]
+[target.'cfg(target_arch = "x86_64")']
 rustflags = ["-C", "target-cpu=x86-64-v3"]
-
-[env]
-# TODO: https://github.com/rust-lang/cc-rs/issues/268 - remove this
-CFLAGS = "-march=x86-64-v3"  # for building zstd

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -53,6 +53,15 @@ jobs:
       - run: sudo apt-get install libwayland-dev libxkbcommon-dev
       - run: cargo +nightly cranky --all-targets -- -D warnings
 
+  test-aarch64:
+    name: cargo test --all-features (aarch64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
+      - uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670  #v1.2.2
+      - run: sudo apt-get install libwayland-dev libxkbcommon-dev
+      - run: cargo test --all-features
+
   deny:
     name: cargo deny --all-features check licenses
     runs-on: ubuntu-22.04

--- a/README.md
+++ b/README.md
@@ -8,9 +8,7 @@ XWayland) applications.
 
 ## Building
 
-wprs is currently only available on x86-64 with AVX2. Support for [ARM](https://github.com/wayland-transpositor/wprs/issues/31) and support for more fast compression implementations welcome.
-
-Currently building wprs without AVX2 will lead to build failures.
+wprs supports x86-64 (SSE2 through AVX2) and aarch64 (NEON).
 
 ### Source
 
@@ -32,7 +30,7 @@ The launcher (`wprs`) requires:
 ## Packaging
 
 We officially maintain [deb](#debian) instructions for Debian-based distros.
-Contributers have also supplied packaging for [docker](#docker) and [arch linux](#arch-linux-aur)
+Contributors have also supplied packaging for [docker](#docker) and [arch linux](#arch-linux-aur)
 
 ### Debian
 

--- a/src/filtering/mod.rs
+++ b/src/filtering/mod.rs
@@ -1,0 +1,427 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! AoS↔SoA transposition and spatial/color filtering for pixel buffers.
+//!
+//! The pipeline transposes pixel data between array-of-structs (RGBA
+//! interleaved) and struct-of-arrays (channels separated), applies
+//! subtract_green (VP8L color decorrelation) and running_difference (delta
+//! encoding) for improved entropy, then feeds the result to zstd.
+//!
+//! Architecture-specific backends:
+//! - `x86`: permutation-based transpose (SSE2 through AVX2)
+//! - `neon`: hardware structure load/store (vld4q/vst4q)
+//!
+//! Ref:
+//! * <https://afrantzis.com/pixel-format-guide/wayland_drm.html>
+//! * <https://en.algorithmica.org/hpc/algorithms/prefix/>
+#[cfg(target_arch = "x86_64")]
+#[path = "x86.rs"]
+mod arch;
+
+#[cfg(target_arch = "aarch64")]
+#[path = "neon.rs"]
+mod arch;
+
+/// Bytes per compression shard fed to zstd. Balances parallelism granularity
+/// against zstd context-window utilisation.
+const COMPRESSION_BLOCK_SIZE: usize = 128 * 1024;
+
+use std::cmp;
+use std::sync::Arc;
+
+use itertools::izip;
+use lagoon::ThreadPool;
+
+use crate::buffer_pointer::BufferPointer;
+use crate::buffer_pointer::KnownSizeBufferPointer;
+use crate::prelude::*;
+use crate::sharding_compression::CompressedShards;
+use crate::sharding_compression::ShardingCompressor;
+use crate::vec4u8::Vec4u8;
+use crate::vec4u8::Vec4u8s;
+
+/// Architecture-specific 32-pixel block kernel.
+pub(crate) trait FilterKernel {
+    type ForwardCarry: Copy + Send;
+    type InverseCarry: Copy + Send;
+
+    fn zero_forward() -> (
+        Self::ForwardCarry,
+        Self::ForwardCarry,
+        Self::ForwardCarry,
+        Self::ForwardCarry,
+    );
+
+    fn zero_inverse() -> (
+        Self::InverseCarry,
+        Self::InverseCarry,
+        Self::InverseCarry,
+        Self::InverseCarry,
+    );
+
+    fn forward_block(
+        input: KnownSizeBufferPointer<Vec4u8, 32>,
+        out0: &mut [u8; 32],
+        out1: &mut [u8; 32],
+        out2: &mut [u8; 32],
+        out3: &mut [u8; 32],
+        prev: (
+            Self::ForwardCarry,
+            Self::ForwardCarry,
+            Self::ForwardCarry,
+            Self::ForwardCarry,
+        ),
+    ) -> (
+        Self::ForwardCarry,
+        Self::ForwardCarry,
+        Self::ForwardCarry,
+        Self::ForwardCarry,
+    );
+
+    fn inverse_block(
+        in0: &[u8; 32],
+        in1: &[u8; 32],
+        in2: &[u8; 32],
+        in3: &[u8; 32],
+        out: &mut [Vec4u8; 32],
+        prev: (
+            Self::InverseCarry,
+            Self::InverseCarry,
+            Self::InverseCarry,
+            Self::InverseCarry,
+        ),
+    ) -> (
+        Self::InverseCarry,
+        Self::InverseCarry,
+        Self::InverseCarry,
+        Self::InverseCarry,
+    );
+}
+
+// --- shared parallel pipeline ---
+
+#[instrument(skip_all, level = "debug")]
+fn aos_to_soa_parallel_compression<K: FilterKernel>(
+    aos: BufferPointer<Vec4u8>,
+    compressor: &mut ShardingCompressor,
+) -> CompressedShards {
+    if aos.is_empty() {
+        return CompressedShards::default();
+    }
+
+    let len = aos.len();
+    let n_blocks = len / 32;
+    let lim = n_blocks * 32;
+    let rem = len % 32;
+    let n_threads = 4;
+    let blocks_per_thread = cmp::max(n_blocks / n_threads, 1);
+    let thread_chunk_size = blocks_per_thread * 32;
+
+    let compressor = Arc::new(compressor.begin());
+    let (aos_to_lim, aos_remainder) = aos.split_at(lim);
+
+    debug_span!("aos_to_soa_u8_32x4_loop").in_scope(|| {
+        ThreadPool::global().scoped(|s| {
+            for (thread_idx, aos) in aos_to_lim.chunks(thread_chunk_size).enumerate() {
+                let compressor = compressor.clone();
+                s.run(move || {
+                    let mut idx = thread_idx * thread_chunk_size;
+                    let mut prev = K::zero_forward();
+                    for aos in aos.chunks(COMPRESSION_BLOCK_SIZE) {
+                        let soa_len = cmp::min(aos.len(), COMPRESSION_BLOCK_SIZE);
+                        let mut soa0 = vec![0; soa_len];
+                        let mut soa1 = vec![0; soa_len];
+                        let mut soa2 = vec![0; soa_len];
+                        let mut soa3 = vec![0; soa_len];
+
+                        for (aos_chunk, soa0_chunk, soa1_chunk, soa2_chunk, soa3_chunk) in izip!(
+                            aos.array_chunks::<32>(),
+                            soa0.as_chunks_mut::<32>().0,
+                            soa1.as_chunks_mut::<32>().0,
+                            soa2.as_chunks_mut::<32>().0,
+                            soa3.as_chunks_mut::<32>().0,
+                        ) {
+                            prev = K::forward_block(
+                                aos_chunk, soa0_chunk, soa1_chunk, soa2_chunk, soa3_chunk, prev,
+                            );
+                        }
+
+                        compressor.compress_shard(idx, soa0);
+                        compressor.compress_shard(idx + len, soa1);
+                        compressor.compress_shard(idx + 2 * len, soa2);
+                        compressor.compress_shard(idx + 3 * len, soa3);
+
+                        idx += aos.len();
+                    }
+                });
+            }
+        });
+    });
+
+    if rem > 0 {
+        let mut rem0 = vec![0u8; rem];
+        let mut rem1 = vec![0u8; rem];
+        let mut rem2 = vec![0u8; rem];
+        let mut rem3 = vec![0u8; rem];
+
+        for (s, r0, r1, r2, r3) in izip!(
+            aos_remainder.into_iter(),
+            &mut rem0,
+            &mut rem1,
+            &mut rem2,
+            &mut rem3
+        ) {
+            *r0 = s.0;
+            *r1 = s.1;
+            *r2 = s.2;
+            *r3 = s.3;
+        }
+
+        compressor.compress_shard(len - rem, rem0);
+        compressor.compress_shard(2 * len - rem, rem1);
+        compressor.compress_shard(3 * len - rem, rem2);
+        compressor.compress_shard(4 * len - rem, rem3);
+    }
+
+    Arc::into_inner(compressor).unwrap().collect_shards()
+}
+
+#[instrument(skip_all, level = "debug")]
+fn soa_to_aos_parallel<K: FilterKernel>(soa: &Vec4u8s, aos: &mut [Vec4u8]) {
+    let len = soa.len();
+    assert_eq!(len, aos.len());
+
+    let n_blocks = len / 32;
+    let lim = n_blocks * 32;
+    let n_threads = 4;
+    let blocks_per_thread = cmp::max(n_blocks / n_threads, 1);
+    let thread_chunk_size = blocks_per_thread * 32;
+
+    let mut prev = K::zero_inverse();
+
+    debug_span!("soa_to_aos_u8_32x4_loop").in_scope(|| {
+        ThreadPool::global().scoped(|s| {
+            for ((soa0, soa1, soa2, soa3), aos) in izip!(
+                soa.chunks(thread_chunk_size),
+                aos.chunks_mut(thread_chunk_size)
+            ) {
+                s.run(move || {
+                    for (soa0_chunk, soa1_chunk, soa2_chunk, soa3_chunk, aos_chunk) in izip!(
+                        soa0.as_chunks::<32>().0,
+                        soa1.as_chunks::<32>().0,
+                        soa2.as_chunks::<32>().0,
+                        soa3.as_chunks::<32>().0,
+                        aos.as_chunks_mut::<32>().0,
+                    ) {
+                        prev = K::inverse_block(
+                            soa0_chunk, soa1_chunk, soa2_chunk, soa3_chunk, aos_chunk, prev,
+                        );
+                    }
+                });
+            }
+        });
+    });
+
+    let (soa0, soa1, soa2, soa3) = soa.parts();
+    for (a, s0, s1, s2, s3) in izip!(
+        &mut aos[lim..len],
+        &soa0[lim..len],
+        &soa1[lim..len],
+        &soa2[lim..len],
+        &soa3[lim..len]
+    ) {
+        *a = Vec4u8(*s0, *s1, *s2, *s3);
+    }
+}
+
+// --- public API ---
+
+pub fn filter_and_compress(
+    data: BufferPointer<u8>,
+    compressor: &mut ShardingCompressor,
+) -> CompressedShards {
+    assert!(data.len().is_multiple_of(4));
+    // SAFETY: Vec4u8 is a repr(C, packed) wrapper around [u8; 4].
+    aos_to_soa_parallel_compression::<arch::Kernel>(unsafe { data.cast::<Vec4u8>() }, compressor)
+}
+
+pub fn unfilter(data: &Vec4u8s, output_buf: &mut [u8]) {
+    soa_to_aos_parallel::<arch::Kernel>(data, bytemuck::cast_slice_mut(output_buf));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroUsize;
+
+    use fallible_iterator::IteratorExt;
+    use proptest::prelude::*;
+
+    use super::*;
+    use crate::sharding_compression::CompressedShard;
+    use crate::sharding_compression::ShardingDecompressor;
+
+    fn test_vec(n: usize) -> Vec<u8> {
+        (0..n).map(|i| (i % 256) as u8).collect()
+    }
+
+    fn test_roundtrip_impl(data: &[u8]) {
+        assert!(data.len().is_multiple_of(4));
+
+        let data_ptr = data.as_ptr();
+        let buf_ptr = unsafe { BufferPointer::new(&data_ptr, data.len()) };
+
+        let mut compressor = ShardingCompressor::new(NonZeroUsize::new(16).unwrap(), 1).unwrap();
+        let shards = filter_and_compress(buf_ptr, &mut compressor);
+
+        let mut decompressor = ShardingDecompressor::new(NonZeroUsize::new(8).unwrap()).unwrap();
+        let indices = shards.indices();
+
+        let soa = decompressor
+            .decompress_to_owned(
+                &indices,
+                data.len(),
+                shards
+                    .shards
+                    .into_iter()
+                    .map(Ok::<CompressedShard, anyhow::Error>)
+                    .transpose_into_fallible(),
+            )
+            .unwrap();
+
+        let mut output = vec![0u8; data.len()];
+        unfilter(&soa.into(), &mut output);
+
+        assert_eq!(data, &output);
+    }
+
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_roundtrip() {
+        for n in [
+            0,
+            4,
+            8,
+            12,
+            16,
+            20,
+            24,
+            28,
+            32,
+            36,
+            120,
+            124,
+            128,
+            132,
+            248,
+            252,
+            256,
+            260,
+            1016,
+            1020,
+            1024,
+            1028,
+            2040,
+            2044,
+            2048,
+            2052,
+            100,
+            1920 * 1080,
+            32768 * 4 + 4,
+            1008 * 9513 * 4,
+            1008 * 951 * 4,
+        ] {
+            test_roundtrip_impl(&test_vec(n));
+        }
+    }
+
+    proptest! {
+        #[test]
+        #[cfg_attr(miri, ignore)]
+        fn proptest_roundtrip(mut arr in proptest::collection::vec(0..u8::MAX, 0..1_000_000)) {
+            arr.truncate((arr.len() / 4) * 4);
+            assert!(arr.len() % 4 == 0);
+            test_roundtrip_impl(&arr);
+        }
+    }
+
+    /// Verify that the filtered SoA output matches known-good values.
+    ///
+    /// This test is architecture-independent: both x86 and aarch64 must
+    /// produce identical compressed shards for the same input, since a
+    /// buffer filtered on one architecture may be unfiltered on another.
+    #[test]
+    #[cfg_attr(miri, ignore)]
+    fn test_filtered_output_deterministic() {
+        // 128 bytes = 32 pixels = exactly one SIMD block on both architectures.
+        let data: Vec<u8> = (0..128u16).map(|i| ((i * 7 + 13) % 256) as u8).collect();
+        let data_ptr = data.as_ptr();
+        let buf_ptr = unsafe { BufferPointer::new(&data_ptr, data.len()) };
+
+        let mut compressor = ShardingCompressor::new(NonZeroUsize::new(16).unwrap(), 1).unwrap();
+        let shards = filter_and_compress(buf_ptr, &mut compressor);
+
+        let mut decompressor = ShardingDecompressor::new(NonZeroUsize::new(8).unwrap()).unwrap();
+        let indices = shards.indices();
+        let soa = decompressor
+            .decompress_to_owned(
+                &indices,
+                data.len(),
+                shards
+                    .shards
+                    .into_iter()
+                    .map(Ok::<CompressedShard, anyhow::Error>)
+                    .transpose_into_fallible(),
+            )
+            .unwrap();
+
+        // SoA layout: 4 channel arrays concatenated, each of length n_pixels.
+        let n = 32;
+        assert!(soa.len() >= 4 * n);
+        let s0 = &soa[0..n];
+        let s1 = &soa[n..2 * n];
+        let s2 = &soa[2 * n..3 * n];
+        let s3 = &soa[3 * n..4 * n];
+
+        // Compute expected values via scalar reference implementation.
+        // Forward: transpose → subtract_green → running_difference.
+        let mut expected = [vec![0u8; n], vec![0u8; n], vec![0u8; n], vec![0u8; n]];
+        for i in 0..n {
+            expected[0][i] = data[i * 4]; // channel 0
+            expected[1][i] = data[i * 4 + 1]; // channel 1 (green)
+            expected[2][i] = data[i * 4 + 2]; // channel 2
+            expected[3][i] = data[i * 4 + 3]; // channel 3
+        }
+        // subtract_green: ch0 -= ch1, ch2 -= ch1.
+        let [ch0, ch1, ch2, ..] = &mut expected;
+        for (b, (g, r)) in ch0.iter_mut().zip(ch1.iter().zip(ch2.iter_mut())) {
+            *b = b.wrapping_sub(*g);
+            *r = r.wrapping_sub(*g);
+        }
+        // running_difference per channel.
+        for ch in &mut expected {
+            let mut prev = 0u8;
+            for v in ch.iter_mut() {
+                let orig = *v;
+                *v = orig.wrapping_sub(prev);
+                prev = orig;
+            }
+        }
+
+        assert_eq!(s0, &expected[0], "channel 0 mismatch");
+        assert_eq!(s1, &expected[1], "channel 1 mismatch");
+        assert_eq!(s2, &expected[2], "channel 2 mismatch");
+        assert_eq!(s3, &expected[3], "channel 3 mismatch");
+    }
+}

--- a/src/filtering/neon.rs
+++ b/src/filtering/neon.rs
@@ -1,0 +1,336 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Filtering pipeline for aarch64 using NEON structure load/store.
+//!
+//! The forward transform (AoS→SoA, subtract_green, running_difference) and
+//! its inverse (prefix_sum, add_green, SoA→AoS) are fused within each
+//! 32-pixel block so channel data stays register-resident across all stages.
+//! The transpose step uses `vld4q_u8`/`vst4q_u8` — hardware four-channel
+//! deinterleave/interleave.
+//!
+//! # `unsafe` and `#[target_feature]`
+//!
+//! NEON is architecturally mandatory on AArch64 (ARMv8-A and later), but
+//! `std::arch::aarch64` intrinsics carry `#[target_feature(enable = "neon")]`.
+//! Per RFC 2396 (stabilized in Rust 1.86), calling such functions requires
+//! `unsafe` unless the *caller* also carries a matching `#[target_feature]`
+//! annotation — the compilation target's default features alone do not
+//! suffice. The `unsafe` blocks in this module exist solely for this reason
+//! when the enclosed operations are register-to-register.
+
+use std::arch::aarch64::*;
+
+// --- 16-byte primitives ---
+
+/// Running difference: `out[i] = in[i] - in[i-1]`, carry in NEON domain.
+#[inline(always)]
+fn running_difference_16(block: uint8x16_t, prev: uint8x16_t) -> (uint8x16_t, uint8x16_t) {
+    // SAFETY: register-to-register NEON; see module doc on #[target_feature].
+    unsafe {
+        let shifted = vextq_u8::<15>(prev, block);
+        (vsubq_u8(block, shifted), vdupq_laneq_u8::<15>(block))
+    }
+}
+
+/// Inclusive prefix sum: Hillis-Steele doubling, 4 steps for 16 lanes.
+#[inline(always)]
+fn prefix_sum_16(mut block: uint8x16_t) -> uint8x16_t {
+    // SAFETY: register-to-register NEON; see module doc on #[target_feature].
+    unsafe {
+        let zero = vdupq_n_u8(0);
+        block = vaddq_u8(block, vextq_u8::<15>(zero, block));
+        block = vaddq_u8(block, vextq_u8::<14>(zero, block));
+        block = vaddq_u8(block, vextq_u8::<12>(zero, block));
+        block = vaddq_u8(block, vextq_u8::<8>(zero, block));
+        block
+    }
+}
+
+/// Chain local prefix sums across blocks via broadcast carry.
+#[inline(always)]
+fn accumulate_16(block: uint8x16_t, carry: uint8x16_t) -> (uint8x16_t, uint8x16_t) {
+    // SAFETY: register-to-register NEON; see module doc on #[target_feature].
+    unsafe {
+        let block_last = vdupq_laneq_u8::<15>(block);
+        (vaddq_u8(block, carry), vaddq_u8(carry, block_last))
+    }
+}
+
+// --- 32-pixel fused blocks ---
+
+/// Forward: deinterleave → subtract_green → running_difference, 32 pixels.
+///
+/// Carry state stays in the NEON register file throughout; the forward and
+/// inverse transforms are now symmetric in their carry representation.
+#[inline]
+fn aos_to_soa_u8_32x4(
+    input: *const u8,
+    out0: &mut [u8; 32],
+    out1: &mut [u8; 32],
+    out2: &mut [u8; 32],
+    out3: &mut [u8; 32],
+    prev0: uint8x16_t,
+    prev1: uint8x16_t,
+    prev2: uint8x16_t,
+    prev3: uint8x16_t,
+) -> (uint8x16_t, uint8x16_t, uint8x16_t, uint8x16_t) {
+    // SAFETY: `input` points to 128 bytes (32 × Vec4u8) from array_chunks::<32>.
+    // vld4q_u8 reads 64 bytes; vst1q_u8 writes 16 bytes per half.
+    unsafe {
+        let lo = vld4q_u8(input);
+        let hi = vld4q_u8(input.add(64));
+
+        let (ch0_lo, ch0_hi) = (lo.0, hi.0);
+        let (ch1_lo, ch1_hi) = (lo.1, hi.1);
+        let (ch2_lo, ch2_hi) = (lo.2, hi.2);
+        let (ch3_lo, ch3_hi) = (lo.3, hi.3);
+
+        // subtract_green: B -= G, R -= G
+        let ch0_lo = vsubq_u8(ch0_lo, ch1_lo);
+        let ch0_hi = vsubq_u8(ch0_hi, ch1_hi);
+        let ch2_lo = vsubq_u8(ch2_lo, ch1_lo);
+        let ch2_hi = vsubq_u8(ch2_hi, ch1_hi);
+
+        // running_difference per channel
+        let (d0_lo, mid0) = running_difference_16(ch0_lo, prev0);
+        let (d0_hi, next0) = running_difference_16(ch0_hi, mid0);
+        let (d1_lo, mid1) = running_difference_16(ch1_lo, prev1);
+        let (d1_hi, next1) = running_difference_16(ch1_hi, mid1);
+        let (d2_lo, mid2) = running_difference_16(ch2_lo, prev2);
+        let (d2_hi, next2) = running_difference_16(ch2_hi, mid2);
+        let (d3_lo, mid3) = running_difference_16(ch3_lo, prev3);
+        let (d3_hi, next3) = running_difference_16(ch3_hi, mid3);
+
+        vst1q_u8(out0.as_mut_ptr(), d0_lo);
+        vst1q_u8(out0.as_mut_ptr().add(16), d0_hi);
+        vst1q_u8(out1.as_mut_ptr(), d1_lo);
+        vst1q_u8(out1.as_mut_ptr().add(16), d1_hi);
+        vst1q_u8(out2.as_mut_ptr(), d2_lo);
+        vst1q_u8(out2.as_mut_ptr().add(16), d2_hi);
+        vst1q_u8(out3.as_mut_ptr(), d3_lo);
+        vst1q_u8(out3.as_mut_ptr().add(16), d3_hi);
+
+        (next0, next1, next2, next3)
+    }
+}
+
+/// Inverse: prefix_sum → add_green → interleave, 32 pixels.
+#[inline]
+fn soa_to_aos_u8_32x4(
+    input0: &[u8; 32],
+    input1: &[u8; 32],
+    input2: &[u8; 32],
+    input3: &[u8; 32],
+    out: &mut [Vec4u8; 32],
+    prev0: uint8x16_t,
+    prev1: uint8x16_t,
+    prev2: uint8x16_t,
+    prev3: uint8x16_t,
+) -> (uint8x16_t, uint8x16_t, uint8x16_t, uint8x16_t) {
+    // SAFETY: vld1q_u8 reads 16 bytes per half; vst4q_u8 writes 64 bytes × 2.
+    unsafe {
+        let ch0_lo = vld1q_u8(input0.as_ptr());
+        let ch0_hi = vld1q_u8(input0.as_ptr().add(16));
+        let ch1_lo = vld1q_u8(input1.as_ptr());
+        let ch1_hi = vld1q_u8(input1.as_ptr().add(16));
+        let ch2_lo = vld1q_u8(input2.as_ptr());
+        let ch2_hi = vld1q_u8(input2.as_ptr().add(16));
+        let ch3_lo = vld1q_u8(input3.as_ptr());
+        let ch3_hi = vld1q_u8(input3.as_ptr().add(16));
+
+        // prefix_sum per channel (inverse of running_difference)
+        let ch0_lo = prefix_sum_16(ch0_lo);
+        let (ch0_lo, prev0) = accumulate_16(ch0_lo, prev0);
+        let ch0_hi = prefix_sum_16(ch0_hi);
+        let (ch0_hi, prev0) = accumulate_16(ch0_hi, prev0);
+
+        let ch1_lo = prefix_sum_16(ch1_lo);
+        let (ch1_lo, prev1) = accumulate_16(ch1_lo, prev1);
+        let ch1_hi = prefix_sum_16(ch1_hi);
+        let (ch1_hi, prev1) = accumulate_16(ch1_hi, prev1);
+
+        let ch2_lo = prefix_sum_16(ch2_lo);
+        let (ch2_lo, prev2) = accumulate_16(ch2_lo, prev2);
+        let ch2_hi = prefix_sum_16(ch2_hi);
+        let (ch2_hi, prev2) = accumulate_16(ch2_hi, prev2);
+
+        let ch3_lo = prefix_sum_16(ch3_lo);
+        let (ch3_lo, prev3) = accumulate_16(ch3_lo, prev3);
+        let ch3_hi = prefix_sum_16(ch3_hi);
+        let (ch3_hi, prev3) = accumulate_16(ch3_hi, prev3);
+
+        // add_green (inverse VP8L): B += G, R += G
+        let ch0_lo = vaddq_u8(ch0_lo, ch1_lo);
+        let ch0_hi = vaddq_u8(ch0_hi, ch1_hi);
+        let ch2_lo = vaddq_u8(ch2_lo, ch1_lo);
+        let ch2_hi = vaddq_u8(ch2_hi, ch1_hi);
+
+        // interleave
+        let out_ptr = out.as_mut_ptr().cast::<u8>();
+        vst4q_u8(out_ptr, uint8x16x4_t(ch0_lo, ch1_lo, ch2_lo, ch3_lo));
+        vst4q_u8(
+            out_ptr.add(64),
+            uint8x16x4_t(ch0_hi, ch1_hi, ch2_hi, ch3_hi),
+        );
+
+        (prev0, prev1, prev2, prev3)
+    }
+}
+
+// --- kernel trait impl ---
+
+use crate::buffer_pointer::KnownSizeBufferPointer;
+use crate::filtering::FilterKernel;
+use crate::vec4u8::Vec4u8;
+
+type Carry4 = (uint8x16_t, uint8x16_t, uint8x16_t, uint8x16_t);
+
+pub(super) struct Kernel;
+
+impl FilterKernel for Kernel {
+    type ForwardCarry = uint8x16_t;
+    type InverseCarry = uint8x16_t;
+
+    fn zero_forward() -> Carry4 {
+        // SAFETY: register broadcast; see module doc on #[target_feature].
+        let z = unsafe { vdupq_n_u8(0) };
+        (z, z, z, z)
+    }
+
+    fn zero_inverse() -> Carry4 {
+        Self::zero_forward()
+    }
+
+    fn forward_block(
+        input: KnownSizeBufferPointer<Vec4u8, 32>,
+        out0: &mut [u8; 32],
+        out1: &mut [u8; 32],
+        out2: &mut [u8; 32],
+        out3: &mut [u8; 32],
+        (p0, p1, p2, p3): Carry4,
+    ) -> Carry4 {
+        aos_to_soa_u8_32x4(
+            input.ptr().cast::<u8>(),
+            out0,
+            out1,
+            out2,
+            out3,
+            p0,
+            p1,
+            p2,
+            p3,
+        )
+    }
+
+    fn inverse_block(
+        in0: &[u8; 32],
+        in1: &[u8; 32],
+        in2: &[u8; 32],
+        in3: &[u8; 32],
+        out: &mut [Vec4u8; 32],
+        (p0, p1, p2, p3): Carry4,
+    ) -> Carry4 {
+        soa_to_aos_u8_32x4(in0, in1, in2, in3, out, p0, p1, p2, p3)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: extract 16 bytes from a NEON register.
+    fn to_array(v: uint8x16_t) -> [u8; 16] {
+        let mut out = [0u8; 16];
+        // SAFETY: vst1q_u8 writes 16 bytes to a 16-byte array.
+        unsafe { vst1q_u8(out.as_mut_ptr(), v) };
+        out
+    }
+
+    /// Helper: load 16 bytes into a NEON register.
+    fn from_array(a: &[u8; 16]) -> uint8x16_t {
+        // SAFETY: vld1q_u8 reads 16 bytes from a 16-byte array.
+        unsafe { vld1q_u8(a.as_ptr()) }
+    }
+
+    #[test]
+    fn test_running_difference_16() {
+        let input: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        // SAFETY: register broadcast; see module doc on #[target_feature].
+        let zero = unsafe { vdupq_n_u8(0) };
+        let (result, carry) = running_difference_16(from_array(&input), zero);
+        assert_eq!(
+            to_array(result),
+            [0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        );
+        assert_eq!(to_array(carry), [15; 16]);
+    }
+
+    #[test]
+    fn test_running_difference_16_with_carry() {
+        let input: [u8; 16] = [
+            10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25,
+        ];
+        // SAFETY: register broadcast; see module doc on #[target_feature].
+        let carry_in = unsafe { vdupq_n_u8(9) };
+        let (result, carry) = running_difference_16(from_array(&input), carry_in);
+        assert_eq!(
+            to_array(result),
+            [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        );
+        assert_eq!(to_array(carry), [25; 16]);
+    }
+
+    #[test]
+    fn test_prefix_sum_16() {
+        let input: [u8; 16] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+        let result = prefix_sum_16(from_array(&input));
+        // Inclusive prefix sum: [0, 0+1, 0+1+2, ...] = [0, 1, 3, 6, 10, 15, 21, 28, ...]
+        assert_eq!(
+            to_array(result),
+            [0, 1, 3, 6, 10, 15, 21, 28, 36, 45, 55, 66, 78, 91, 105, 120]
+        );
+    }
+
+    #[test]
+    fn test_prefix_sum_roundtrip() {
+        // prefix_sum is left inverse of running_difference.
+        let input: [u8; 16] = [
+            42, 17, 255, 0, 1, 128, 99, 200, 3, 7, 11, 13, 50, 60, 70, 80,
+        ];
+        // SAFETY: register broadcast; see module doc on #[target_feature].
+        let zero = unsafe { vdupq_n_u8(0) };
+        let (diff, carry) = running_difference_16(from_array(&input), zero);
+        let recovered = prefix_sum_16(diff);
+        assert_eq!(to_array(recovered), input);
+        assert_eq!(to_array(carry), [80; 16]);
+    }
+
+    #[test]
+    fn test_accumulate_16() {
+        let block: [u8; 16] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+        // SAFETY: register broadcast; see module doc on #[target_feature].
+        let carry = unsafe { vdupq_n_u8(100) };
+        let (result, new_carry) = accumulate_16(from_array(&block), carry);
+        // Each element += 100.
+        assert_eq!(
+            to_array(result),
+            [
+                101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116
+            ]
+        );
+        // New carry = old carry + last element of block = 100 + 16 = 116.
+        assert_eq!(to_array(new_carry), [116; 16]);
+    }
+}

--- a/src/filtering/x86.rs
+++ b/src/filtering/x86.rs
@@ -17,18 +17,9 @@
 /// * https://afrantzis.com/pixel-format-guide/wayland_drm.html
 /// * https://stackoverflow.com/questions/44984724/whats-the-fastest-stride-3-gather-instruction-sequence.
 /// * https://en.algorithmica.org/hpc/algorithms/prefix/.
-use std::cmp;
 use std::ops::IndexMut;
-use std::sync::Arc;
 
-use itertools::izip;
-use lagoon::ThreadPool;
-
-use crate::buffer_pointer::BufferPointer;
 use crate::buffer_pointer::KnownSizeBufferPointer;
-use crate::prelude::*;
-use crate::sharding_compression::CompressedShards;
-use crate::sharding_compression::ShardingCompressor;
 use crate::simd::__m128i;
 use crate::simd::__m256i;
 use crate::simd::_mm_add_epi8;
@@ -54,7 +45,6 @@ use crate::simd::_mm256_slli_si256;
 use crate::simd::_mm256_storeu_si256;
 use crate::simd::_mm256_sub_epi8;
 use crate::vec4u8::Vec4u8;
-use crate::vec4u8::Vec4u8s;
 
 #[inline]
 fn _mm256_shufps_epi32<const MASK: i32>(a: __m256i, b: __m256i) -> __m256i {
@@ -514,190 +504,55 @@ fn soa_to_aos_u8_32x4(
     }
 }
 
-#[instrument(skip_all, level = "debug")]
-fn vec4u8_aos_to_soa_avx2_parallel_compression(
-    aos: BufferPointer<Vec4u8>,
-    compressor: &mut ShardingCompressor,
-) -> CompressedShards {
-    if aos.is_empty() {
-        return CompressedShards::default();
+// --- kernel trait impl ---
+
+use crate::filtering::FilterKernel;
+
+pub(super) struct Kernel;
+
+impl FilterKernel for Kernel {
+    type ForwardCarry = u8;
+    type InverseCarry = __m128i;
+
+    fn zero_forward() -> (u8, u8, u8, u8) {
+        (0, 0, 0, 0)
     }
 
-    let len = aos.len();
-
-    // aos_to_soa_u8_32x4 operates on blocks of 1024 bits aka 128 bytes aka 32
-    // Vec4u8s.
-    let n_blocks = len / 32; // number of 32x Vec4u8 blocks
-    let lim = n_blocks * 32; // number of Vec4u8s to transpose in blocks
-    let rem = len % 32; // remaining Vec4u8s to transpose individually
-    let n_threads = 4;
-    let blocks_per_thread = cmp::max(n_blocks / n_threads, 1);
-    let thread_chunk_size = blocks_per_thread * 32;
-
-    let compressor = Arc::new(compressor.begin());
-    let compression_block_size = 128 * 1024;
-
-    let (aos_to_lim, aos_remainder) = aos.split_at(lim);
-
-    debug_span!("aos_to_soa_u8_32x4_loop").in_scope(|| {
-        ThreadPool::global().scoped(|s| {
-            for (thread_idx, aos) in aos_to_lim.chunks(thread_chunk_size).enumerate() {
-                let compressor = compressor.clone();
-                s.run(move || {
-                    let mut idx = thread_idx * thread_chunk_size;
-                    let (mut prev0, mut prev1, mut prev2, mut prev3) = (0, 0, 0, 0);
-                    for aos in aos.chunks(compression_block_size) {
-                        let soa_len = cmp::min(aos.len(), compression_block_size);
-                        let mut soa0 = vec![0; soa_len];
-                        let mut soa1 = vec![0; soa_len];
-                        let mut soa2 = vec![0; soa_len];
-                        let mut soa3 = vec![0; soa_len];
-
-                        for (aos_chunk, soa0_chunk, soa1_chunk, soa2_chunk, soa3_chunk) in izip!(
-                            aos.array_chunks::<32>(),
-                            soa0.as_chunks_mut::<32>().0,
-                            soa1.as_chunks_mut::<32>().0,
-                            soa2.as_chunks_mut::<32>().0,
-                            soa3.as_chunks_mut::<32>().0,
-                        ) {
-                            (prev0, prev1, prev2, prev3) = aos_to_soa_u8_32x4(
-                                aos_chunk, soa0_chunk, soa1_chunk, soa2_chunk, soa3_chunk, prev0,
-                                prev1, prev2, prev3,
-                            );
-                        }
-
-                        compressor.compress_shard(idx, soa0);
-                        compressor.compress_shard(idx + len, soa1);
-                        compressor.compress_shard(idx + 2 * len, soa2);
-                        compressor.compress_shard(idx + 3 * len, soa3);
-
-                        idx += aos.len();
-                    }
-                });
-            }
-        });
-    });
-
-    if rem > 0 {
-        let mut rem0 = vec![0u8; rem];
-        let mut rem1 = vec![0u8; rem];
-        let mut rem2 = vec![0u8; rem];
-        let mut rem3 = vec![0u8; rem];
-
-        for (s, r0, r1, r2, r3) in izip!(
-            aos_remainder.into_iter(),
-            &mut rem0,
-            &mut rem1,
-            &mut rem2,
-            &mut rem3
-        ) {
-            *r0 = s.0;
-            *r1 = s.1;
-            *r2 = s.2;
-            *r3 = s.3;
-        }
-
-        compressor.compress_shard(len - rem, rem0);
-        compressor.compress_shard(2 * len - rem, rem1);
-        compressor.compress_shard(3 * len - rem, rem2);
-        compressor.compress_shard(4 * len - rem, rem3);
-    }
-
-    // All the other clones of the Arc were inside the loops above.
-    Arc::into_inner(compressor).unwrap().collect_shards()
-}
-
-#[instrument(skip_all, level = "debug")]
-fn vec4u8_soa_to_aos_avx2_parallel(soa: &Vec4u8s, aos: &mut [Vec4u8]) {
-    let len = soa.len();
-    assert_eq!(len, aos.len());
-
-    // soa_to_aos_u8_32x4 operates on blocks of 1024 bits aka 128 bytes aka 32
-    // Vec4u8s.
-    let n_blocks = len / 32; // number of 32x Vec4u8 blocks
-    let lim = n_blocks * 32; // number of Vec4u8s to transpose in blocks
-    let n_threads = 4;
-    let blocks_per_thread = cmp::max(n_blocks / n_threads, 1);
-    let thread_chunk_size = blocks_per_thread * 32;
-
-    // SAFETY: simd/mod.rs exposes versions of this function for SSE2, SSSE3,
-    // SSE4.1, AVX, and AVX2. Which version is used depends on compiler flags,
-    // but there is no good way to plumb that through to avoid the unsafe.
-    unsafe {
-        let z = _mm_setzero_si128();
-        let (mut prev0, mut prev1, mut prev2, mut prev3) = (z, z, z, z);
-
-        debug_span!("soa_to_aos_u8_32x4_loop").in_scope(|| {
-            ThreadPool::global().scoped(|s| {
-                for ((soa0, soa1, soa2, soa3), aos) in izip!(
-                    soa.chunks(thread_chunk_size),
-                    aos.chunks_mut(thread_chunk_size)
-                ) {
-                    s.run(move || {
-                        for (soa0_chunk, soa1_chunk, soa2_chunk, soa3_chunk, aos_chunk) in izip!(
-                            soa0.as_chunks::<32>().0,
-                            soa1.as_chunks::<32>().0,
-                            soa2.as_chunks::<32>().0,
-                            soa3.as_chunks::<32>().0,
-                            aos.as_chunks_mut::<32>().0,
-                        ) {
-                            (prev0, prev1, prev2, prev3) = soa_to_aos_u8_32x4(
-                                soa0_chunk, soa1_chunk, soa2_chunk, soa3_chunk, aos_chunk, prev0,
-                                prev1, prev2, prev3,
-                            );
-                        }
-                    });
-                }
-            });
-        });
-
-        let (soa0, soa1, soa2, soa3) = soa.parts();
-        for (a, s0, s1, s2, s3) in izip!(
-            &mut aos[lim..len],
-            &soa0[lim..len],
-            &soa1[lim..len],
-            &soa2[lim..len],
-            &soa3[lim..len]
-        ) {
-            *a = Vec4u8(*s0, *s1, *s2, *s3);
+    fn zero_inverse() -> (__m128i, __m128i, __m128i, __m128i) {
+        // SAFETY: simd/mod.rs exposes versions of this function for SSE2,
+        // SSSE3, SSE4.1, AVX, and AVX2.
+        unsafe {
+            let z = _mm_setzero_si128();
+            (z, z, z, z)
         }
     }
-}
 
-fn vec4u8_aos_to_soa(
-    aos: BufferPointer<Vec4u8>,
-    compressor: &mut ShardingCompressor,
-) -> CompressedShards {
-    vec4u8_aos_to_soa_avx2_parallel_compression(aos, compressor)
-}
+    fn forward_block(
+        input: KnownSizeBufferPointer<Vec4u8, 32>,
+        out0: &mut [u8; 32],
+        out1: &mut [u8; 32],
+        out2: &mut [u8; 32],
+        out3: &mut [u8; 32],
+        (p0, p1, p2, p3): (u8, u8, u8, u8),
+    ) -> (u8, u8, u8, u8) {
+        aos_to_soa_u8_32x4(input, out0, out1, out2, out3, p0, p1, p2, p3)
+    }
 
-fn vec4u8_soa_to_aos(soa: &Vec4u8s, aos: &mut [Vec4u8]) {
-    vec4u8_soa_to_aos_avx2_parallel(soa, aos)
-}
-
-pub fn filter_and_compress(
-    data: BufferPointer<u8>,
-    compressor: &mut ShardingCompressor,
-) -> CompressedShards {
-    assert!(data.len().is_multiple_of(4)); // data is a buffer of argb or xrgb pixels.
-    // SAFETY: Vec4u8 is a repr(C, packed) wrapper around [u8; 4].
-    vec4u8_aos_to_soa(unsafe { data.cast::<Vec4u8>() }, compressor)
-}
-
-pub fn unfilter(data: &Vec4u8s, output_buf: &mut [u8]) {
-    vec4u8_soa_to_aos(data, bytemuck::cast_slice_mut(output_buf));
+    fn inverse_block(
+        in0: &[u8; 32],
+        in1: &[u8; 32],
+        in2: &[u8; 32],
+        in3: &[u8; 32],
+        out: &mut [Vec4u8; 32],
+        (p0, p1, p2, p3): (__m128i, __m128i, __m128i, __m128i),
+    ) -> (__m128i, __m128i, __m128i, __m128i) {
+        soa_to_aos_u8_32x4(in0, in1, in2, in3, out, p0, p1, p2, p3)
+    }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::num::NonZeroUsize;
-
-    use fallible_iterator::IteratorExt;
-    use proptest::prelude::*;
-
     use super::*;
-    use crate::sharding_compression::CompressedShard;
-    use crate::sharding_compression::ShardingDecompressor;
 
     #[test]
     #[cfg_attr(miri, ignore)]
@@ -741,97 +596,5 @@ mod tests {
             1, 1, 1,
         ];
         assert_eq!(output, expected);
-    }
-
-    fn test_vec(n: usize) -> Vec<u8> {
-        (0..n).map(|i| (i % 256) as u8).collect()
-    }
-
-    fn generate_aos(input: &[u8]) -> Vec<Vec4u8> {
-        input
-            .chunks(4)
-            .map(|chunk| Vec4u8(chunk[0], chunk[1], chunk[2], chunk[3]))
-            .collect()
-    }
-
-    fn test_roundtrip_impl(data: &[u8]) {
-        assert!(data.len().is_multiple_of(4));
-
-        let aos: Vec<Vec4u8> = generate_aos(data);
-        let aos_ptr = aos.as_ptr();
-        let aos_buf_ptr = unsafe { BufferPointer::new(&aos_ptr, aos.len()) };
-
-        let mut compressor = ShardingCompressor::new(NonZeroUsize::new(16).unwrap(), 1).unwrap();
-        let shards = vec4u8_aos_to_soa(aos_buf_ptr, &mut compressor);
-
-        let mut decompressor = ShardingDecompressor::new(NonZeroUsize::new(8).unwrap()).unwrap();
-        let indices = shards.indices();
-
-        let soa = decompressor
-            .decompress_to_owned(
-                &indices,
-                data.len(),
-                shards
-                    .shards
-                    .into_iter()
-                    .map(Ok::<CompressedShard, anyhow::Error>)
-                    .transpose_into_fallible(),
-            )
-            .unwrap();
-
-        let mut expected_aos: Vec<Vec4u8> = vec![Vec4u8::new(); data.len() / 4];
-        vec4u8_soa_to_aos(&soa.into(), &mut expected_aos);
-
-        assert_eq!(aos, expected_aos);
-    }
-
-    #[test]
-    #[cfg_attr(miri, ignore)]
-    fn test_roundtrip() {
-        for n in vec![
-            0,
-            4,
-            8,
-            12,
-            16,
-            20,
-            24,
-            28,
-            32,
-            36,
-            120,
-            124,
-            128,
-            132,
-            248,
-            252,
-            256,
-            260,
-            1016,
-            1020,
-            1024,
-            1028,
-            2040,
-            2044,
-            2048,
-            2052,
-            100,
-            1920 * 1080,
-            32768 * 4 + 4,
-            1008 * 9513 * 4,
-            1008 * 951 * 4,
-        ] {
-            test_roundtrip_impl(&test_vec(n));
-        }
-    }
-
-    proptest! {
-        #[test]
-        #[cfg_attr(miri, ignore)]
-        fn proptest_roundtrip(mut arr in proptest::collection::vec(0..u8::MAX, 0..1_000_000)) {
-            arr.truncate((arr.len() / 4) * 4);
-            assert!(arr.len() % 4 == 0);
-            test_roundtrip_impl(&arr);
-        }
     }
 }

--- a/src/simd/mod.rs
+++ b/src/simd/mod.rs
@@ -38,15 +38,22 @@ cfg_if! {
         mod sse2_base;
         mod sse2;
         pub use crate::simd::sse2::*;
+    } else if #[cfg(target_arch = "aarch64")] {
+        // The aarch64 filtering pipeline uses NEON structure load/store
+        // instructions (vld4q/vst4q) directly, bypassing this abstraction
+        // layer entirely. See filtering/neon.rs.
     } else {
-        compile_error!("x86_64 SIMD support is required.");
+        compile_error!("Requires x86_64 (SSE2+) or aarch64 (NEON).");
     }
 }
 
+// Debug helpers for x86 vector types. These use the x86 SIMD types re-exported
+// above and are only meaningful on x86_64.
+#[cfg(target_arch = "x86_64")]
 #[allow(dead_code)]
 pub fn print_vec_char_128_dec(x: __m128i) {
     let mut v = [0u8; 16];
-    // SAFETY: dst is 16 * 8 = bytes
+    // SAFETY: dst is 16 bytes, matching the 128-bit source.
     unsafe {
         _mm_storeu_si128(v.as_mut_ptr().cast::<__m128i>(), x);
     }
@@ -71,10 +78,11 @@ pub fn print_vec_char_128_dec(x: __m128i) {
     );
 }
 
+#[cfg(target_arch = "x86_64")]
 #[allow(dead_code)]
 pub fn print_vec_char_256_hex(x: __m256i) {
     let mut v = [0u8; 32];
-    // SAFETY: dst is 32 * 8 = bytes
+    // SAFETY: dst is 32 bytes, matching the 256-bit source.
     unsafe {
         _mm256_storeu_si256(v.as_mut_ptr().cast::<__m256i>(), x);
     }


### PR DESCRIPTION
NEON implementation of the filtering pipeline for aarch64.

Uses structure load/store (`vld4q_u8`/`vst4q_u8`) for hardware
four-channel deinterleave, replacing the permutation-based transpose.
Forward and inverse transforms fused per 32-pixel block with carry
state held in the register file. Hillis-Steele prefix sum for the
inverse path.

- `src/filtering/` split into `mod.rs` (dispatch + shared tests),
  `x86.rs` (existing, renamed), `neon.rs` (new)
- `simd/mod.rs` updated with aarch64 branch (NEON bypasses the
  abstraction layer — structure load/store is a different approach)
- `.cargo/config.toml` uses `cfg(target_arch)` for portable target selection
- aarch64 CI job added to presubmit
- Architecture-independent roundtrip, proptest, and deterministic
  output tests verify cross-architecture compatibility
- README updated

Closes #31.