### PR TITLE
bug fix: panic during attach when syncing surfaces without buffers

### DIFF
--- a/src/server/client_handlers.rs
+++ b/src/server/client_handlers.rs
@@ -636,13 +636,18 @@ impl WprsServerState {
                 .clone();
 
             let mut surface_state_to_send = surface_state.clone_without_buffer();
-            let raw_buffer_to_send = surface_state_to_send
-                .update_with_external_buffer(&surface_state.buffer)
-                .unwrap();
 
-            self.serializer
-                .writer()
-                .send(SendType::RawBuffer(raw_buffer_to_send));
+            if let Some(crate::serialization::wayland::BufferAssignment::New(_)) =
+                &surface_state.buffer
+            {
+                let raw_buffer_to_send = surface_state_to_send
+                    .update_with_external_buffer(&surface_state.buffer)
+                    .unwrap();
+
+                self.serializer
+                    .writer()
+                    .send(SendType::RawBuffer(raw_buffer_to_send));
+            }
 
             self.serializer
                 .writer()


### PR DESCRIPTION
Tested this and it should fix this error from wprsd:
```
  thread 'main' panicked at src/server/client_handlers.rs:641:18:
  called `Result::unwrap()` on an `Err` value: wprs::serialization::wayland::SurfaceState::update_with_external_buffer at src/serialization/wayland.rs:750
```

reproduce by running `wprs <host> run foot`, `wprs detach`, `wprs attach`