### PR TITLE
Fix compositor panic and remote XDG_RUNTIME_DIR handling

### DIFF
--- a/src/client/xdg_shell.rs
+++ b/src/client/xdg_shell.rs
@@ -66,14 +66,29 @@ impl RemoteXdgToplevel {
         object_bimap: &mut ObjectBimap,
         title_prefix: &str,
     ) -> Result<()> {
-        let local_surface = {
+        {
             let surface = surfaces.get_mut(&surface_id).location(loc!())?;
             if surface.role.is_some() {
                 return Ok(());
             }
-            surface.local_surface.take().location(loc!())?
-        };
+            if surface.local_surface.is_none() {
+                bail!("local_surface is None");
+            }
+        }
         let toplevel_state = surface_state.xdg_toplevel()?;
+
+        if let Some(id) = toplevel_state.parent {
+            surfaces
+                .get(&id)
+                .location(loc!())?
+                .xdg_toplevel()
+                .location(loc!())?;
+        }
+
+        let local_surface = {
+            let surface = surfaces.get_mut(&surface_id).location(loc!())?;
+            surface.local_surface.take().unwrap()
+        };
 
         let local_window =
             xdg_shell_state.create_window(local_surface, WindowDecorations::ServerDefault, qh);
@@ -308,13 +323,15 @@ impl RemoteXdgPopup {
         qh: &QueueHandle<WprsClientState>,
         object_bimap: &mut ObjectBimap,
     ) -> Result<()> {
-        let local_surface = {
+        {
             let surface = surfaces.get_mut(&surface_id).location(loc!())?;
             if surface.role.is_some() {
                 return Ok(());
             }
-            surface.local_surface.take().location(loc!())?
-        };
+            if surface.local_surface.is_none() {
+                bail!("local_surface is None");
+            }
+        }
         let popup_state = surface_state.xdg_popup().location(loc!())?;
 
         let parent = {
@@ -332,6 +349,11 @@ impl RemoteXdgPopup {
 
         let positioner =
             Self::new_positioner(xdg_shell_state, &popup_state.positioner).location(loc!())?;
+
+        let local_surface = {
+            let surface = surfaces.get_mut(&surface_id).location(loc!())?;
+            surface.local_surface.take().unwrap()
+        };
 
         let local_popup = popup::Popup::from_surface(
             parent.as_ref(),

--- a/src/server/smithay_handlers.rs
+++ b/src/server/smithay_handlers.rs
@@ -979,6 +979,10 @@ impl SeatHandler for WprsServerState {
 impl WprsServerState {
     fn set_decoration_mode(&self, surface: &WlSurface, mode: Option<DecorationMode>) {
         compositor::with_states(surface, |surface_data| {
+            surface_data.data_map.insert_if_missing_threadsafe(|| {
+                LockedSurfaceState(std::sync::Mutex::new(SurfaceState::new(surface, None).unwrap()))
+            });
+
             let surface_state = &mut surface_data
                 .data_map
                 .get::<LockedSurfaceState>()

--- a/wprs
+++ b/wprs
@@ -231,7 +231,15 @@ def run_remote_command_with_stdout(remote_cmd: list[str]) -> str:
     text=True).stdout.strip()
 
 def remote_socket_dir() -> str:
-  return remote_env_var('XDG_RUNTIME_DIR') or remote_env_var('TEMPDIR') or '/tmp'
+  val = remote_env_var('XDG_RUNTIME_DIR')
+  if val:
+    return val
+  uid = run_remote_command_with_stdout(['id', '-u'])
+  path = f'/run/user/{uid}'
+  exists = run_remote_command_with_stdout(['sh', '-c', f'"test -d {path} && echo yes || echo no"'])
+  if exists == 'yes':
+    return path
+  return remote_env_var('TEMPDIR') or '/tmp'
 
 
 def forward_wprs_sock() -> None:
@@ -464,6 +472,7 @@ def get_env_vars_to_forward() -> dict[str, str]:
 
 def start_remote_command(caps: Capabilities | None) -> None:
   env = {
+    'XDG_RUNTIME_DIR': remote_socket_dir(),
     'WAYLAND_DEBUG': str(int(args.command_wayland_debug)),
     'WAYLAND_DISPLAY': args.wprsd_wayland_display,
     'SSH_AUTH_SOCK': f'{remote_socket_dir()}/wprs-ssh-auth.sock',


### PR DESCRIPTION
Fixes a crash in the remote wprsd compositor when clients request server-side decoration preferences before first commit, and improves the launcher's remote environment handling.