### PR TITLE
Fix clippy lints from newer nightly

### DIFF
--- a/src/bin/wprsc.rs
+++ b/src/bin/wprsc.rs
@@ -140,7 +140,7 @@ fn main() -> Result<()> {
     let mut serializer = Serializer::new_client(&config.socket).with_context(loc!(), || {
         format!(
             "Serializer unable to connect to socket {:?}.",
-            &config.socket
+            config.socket
         )
     })?;
     let reader = serializer.reader().location(loc!())?;

--- a/src/server/client_handlers.rs
+++ b/src/server/client_handlers.rs
@@ -18,6 +18,7 @@ use std::collections::hash_map::Entry;
 use std::fs::File;
 use std::io::Read;
 use std::io::Write;
+use std::mem;
 use std::os::fd::AsFd;
 use std::thread;
 
@@ -161,7 +162,7 @@ impl WprsServerState {
                     // and get data_device events instead. To prevent dropping early, we shouldn't release
                     // these keys yet.
                     if self.dnd_source.is_none() {
-                        let pressed_buttons: HashSet<u32> = self.pressed_buttons.drain().collect();
+                        let pressed_buttons: HashSet<u32> = mem::take(&mut self.pressed_buttons);
                         for button in pressed_buttons {
                             debug!("releasing button {}", button);
                             pointer.button(
@@ -760,7 +761,7 @@ impl WprsServerState {
                             time,
                         },
                     );
-                    let pressed_buttons: HashSet<u32> = self.pressed_buttons.drain().collect();
+                    let pressed_buttons: HashSet<u32> = mem::take(&mut self.pressed_buttons);
                     for button in pressed_buttons {
                         debug!("releasing button {}", button);
                         pointer.button(

--- a/src/sharding_compression.rs
+++ b/src/sharding_compression.rs
@@ -67,7 +67,7 @@ impl fmt::Debug for CompressedShard {
         f.debug_struct("CompressedShard")
             .field("idx", &self.idx)
             .field("compression", &self.compression)
-            .field("data", &format_args!("Vec<u8>[{:?}]", &self.data.len()))
+            .field("data", &format_args!("Vec<u8>[{:?}]", self.data.len()))
             .finish()
     }
 }


### PR DESCRIPTION
The `cranky` presubmit job runs on the floating `nightly` channel, so newly
stabilised lints break CI on `master` without any code change. It is currently
failing with 4 errors:

- `clippy::drain_collect` — `src/server/client_handlers.rs`
- `clippy::useless_borrows_in_formatting` — `src/sharding_compression.rs`,
  `src/bin/wprsc.rs`

All four are the mechanical rewrites clippy suggests (`mem::take` for the
former, dropping a redundant `&` for the latter). No behaviour change.

Verified locally: `cargo +nightly fmt -- --check`, `cargo +nightly cranky
--all-targets -- -D warnings`, `cargo test --all-features`, and `cargo +nightly
miri test` all pass.