### PR TITLE
Apply the viewport when converting surface damage to buffer damage

### DIFF
--- a/src/bin/wprsc.rs
+++ b/src/bin/wprsc.rs
@@ -140,7 +140,7 @@ fn main() -> Result<()> {
     let mut serializer = Serializer::new_client(&config.socket).with_context(loc!(), || {
         format!(
             "Serializer unable to connect to socket {:?}.",
-            &config.socket
+            config.socket
         )
     })?;
     let reader = serializer.reader().location(loc!())?;

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -587,25 +587,40 @@ impl RemoteSurface {
         let Ok(wp_viewporter) = wp_viewporter.get() else {
             return;
         };
-        let Some(viewport_state) = viewport_state else {
+
+        // None still has to clear a viewport we set earlier.
+        let viewport_state = viewport_state.unwrap_or(ViewportState {
+            src: None,
+            dst: None,
+        });
+
+        // skip if the viewport state hasn't changed
+        if self.current_viewport_state == Some(viewport_state) {
             return;
-        };
+        }
+
+        // Don't create a viewport object just to unset a viewport we never set.
+        if self.viewport.is_none() && viewport_state.src.is_none() && viewport_state.dst.is_none() {
+            self.current_viewport_state = Some(viewport_state);
+            return;
+        }
 
         let wl_surface = self.wl_surface().clone();
         let viewport = self
             .viewport
             .get_or_insert_with(|| wp_viewporter.get_viewport(&wl_surface, qh, ()));
 
-        // skip if the viewport state hasn't changed
-        if self.current_viewport_state != Some(viewport_state) {
-            if let Some(src) = viewport_state.src {
-                viewport.set_source(src.loc.x, src.loc.y, src.size.w, src.size.h);
-            }
-            if let Some(dst) = viewport_state.dst {
-                viewport.set_destination(dst.w, dst.h);
-            }
-            self.current_viewport_state = Some(viewport_state);
+        // wp_viewport keeps the previous source/destination until explicitly
+        // unset with the -1 sentinels.
+        match viewport_state.src {
+            Some(src) => viewport.set_source(src.loc.x, src.loc.y, src.size.w, src.size.h),
+            None => viewport.set_source(-1.0, -1.0, -1.0, -1.0),
         }
+        match viewport_state.dst {
+            Some(dst) => viewport.set_destination(dst.w, dst.h),
+            None => viewport.set_destination(-1, -1),
+        }
+        self.current_viewport_state = Some(viewport_state);
     }
 
     pub fn set_input_region(

--- a/src/compositor_utils.rs
+++ b/src/compositor_utils.rs
@@ -218,3 +218,136 @@ pub fn surface_damage_to_buffer(
         .to_i32_up::<i32>()
         .to_buffer(buffer_scale, transform, &area)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::serialization::geometry;
+
+    fn viewport(src: Option<geometry::Rectangle<f64>>, dst: Option<(i32, i32)>) -> ViewportState {
+        ViewportState {
+            src,
+            dst: dst.map(|(w, h)| geometry::Size { w, h }),
+        }
+    }
+
+    fn damage(x: i32, y: i32, w: i32, h: i32) -> Rectangle<i32, Logical> {
+        Rectangle::new(Point::from((x, y)), Size::from((w, h)))
+    }
+
+    fn buffer_rect(x: i32, y: i32, w: i32, h: i32) -> Rectangle<i32, BufferCoords> {
+        Rectangle::new(Point::from((x, y)), Size::from((w, h)))
+    }
+
+    /// A surface with no viewport and a buffer matching its size needs no
+    /// conversion at all.
+    #[test]
+    fn identity() {
+        assert_eq!(
+            surface_damage_to_buffer(
+                damage(10, 20, 30, 40),
+                1,
+                Transform::Normal,
+                None,
+                Some((100, 100))
+            ),
+            buffer_rect(10, 20, 30, 40),
+        );
+    }
+
+    /// Without a buffer there is nothing to scale against, so buffer_scale is
+    /// all we can apply.
+    #[test]
+    fn no_buffer_uses_buffer_scale_only() {
+        assert_eq!(
+            surface_damage_to_buffer(damage(10, 20, 30, 40), 2, Transform::Normal, None, None),
+            buffer_rect(20, 40, 60, 80),
+        );
+    }
+
+    #[test]
+    fn buffer_scale_without_viewport() {
+        assert_eq!(
+            surface_damage_to_buffer(
+                damage(10, 20, 30, 40),
+                2,
+                Transform::Normal,
+                None,
+                Some((200, 200))
+            ),
+            buffer_rect(20, 40, 60, 80),
+        );
+    }
+
+    /// Regression test for damage covering only the top-left corner of the
+    /// buffer. Chromium leaves buffer_scale at 1 and scales through the
+    /// viewport instead, so the destination ratio is the only thing that
+    /// relates surface coordinates to the 2x buffer.
+    #[test]
+    fn viewport_destination_scales_damage() {
+        let viewport = viewport(None, Some((1733, 729)));
+        let buffer = Some((3466, 1458));
+
+        // Full-surface damage has to reach the whole buffer.
+        assert_eq!(
+            surface_damage_to_buffer(
+                damage(0, 0, 1733, 729),
+                1,
+                Transform::Normal,
+                Some(&viewport),
+                buffer
+            ),
+            buffer_rect(0, 0, 3466, 1458),
+        );
+
+        // And a partial rect keeps its position relative to the buffer.
+        assert_eq!(
+            surface_damage_to_buffer(
+                damage(16, 153, 1701, 403),
+                1,
+                Transform::Normal,
+                Some(&viewport),
+                buffer
+            ),
+            buffer_rect(32, 306, 3402, 806),
+        );
+    }
+
+    /// The viewport source rectangle is defined in surface-local coordinates,
+    /// so it both sets the pre-destination size and offsets the result.
+    #[test]
+    fn viewport_source_crops_and_offsets() {
+        let viewport = viewport(
+            Some(geometry::Rectangle::new(10.0, 10.0, 100.0, 50.0)),
+            Some((200, 100)),
+        );
+        assert_eq!(
+            surface_damage_to_buffer(
+                damage(0, 0, 200, 100),
+                1,
+                Transform::Normal,
+                Some(&viewport),
+                Some((400, 200))
+            ),
+            buffer_rect(10, 10, 100, 50),
+        );
+    }
+
+    /// Damage must never come out too small: a rect that lands on fractional
+    /// coordinates has to grow to cover them.
+    #[test]
+    fn rounds_outward() {
+        let viewport = viewport(None, Some((100, 100)));
+        // 3/2 scaling: x 1 -> 1.5 floors to 1, right edge 2 -> 3.0 stays 3.
+        assert_eq!(
+            surface_damage_to_buffer(
+                damage(1, 1, 1, 1),
+                1,
+                Transform::Normal,
+                Some(&viewport),
+                Some((150, 150))
+            ),
+            buffer_rect(1, 1, 2, 2),
+        );
+    }
+}

--- a/src/compositor_utils.rs
+++ b/src/compositor_utils.rs
@@ -22,6 +22,12 @@ use smithay::output::Scale;
 use smithay::reexports::wayland_server::Resource;
 use smithay::reexports::wayland_server::protocol::wl_buffer::WlBuffer;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::utils::Buffer as BufferCoords;
+use smithay::utils::Logical;
+use smithay::utils::Point;
+use smithay::utils::Rectangle;
+use smithay::utils::Size;
+use smithay::utils::Transform;
 use smithay::utils::user_data::UserDataMap;
 use smithay::wayland::compositor::SurfaceAttributes;
 use smithay::wayland::shm;
@@ -31,6 +37,7 @@ use smithay::wayland::shm::BufferData;
 use crate::buffer_pointer::BufferPointer;
 use crate::prelude::*;
 use crate::serialization::wayland::OutputInfo;
+use crate::serialization::wayland::ViewportState;
 
 /// # Panics
 /// If smithay has a bug and with_buffer_contents gives us an invalid pointer.
@@ -150,4 +157,64 @@ pub fn update_surface_outputs<'a, F>(
             output.leave(surface);
         }
     }
+}
+
+/// Convert a damage rectangle from surface coordinates to buffer coordinates.
+///
+/// The viewport is part of this mapping, not just buffer_scale: chromium leaves
+/// buffer_scale at 1 and scales entirely through the viewport, so using
+/// buffer_scale alone makes this the identity and the damage then covers only
+/// the top-left corner of the buffer.
+pub fn surface_damage_to_buffer(
+    rect: Rectangle<i32, Logical>,
+    buffer_scale: i32,
+    transform: Transform,
+    viewport_state: Option<&ViewportState>,
+    buffer_size: Option<(i32, i32)>,
+) -> Rectangle<i32, BufferCoords> {
+    let src = viewport_state.and_then(|viewport_state| viewport_state.src);
+    let dst = viewport_state.and_then(|viewport_state| viewport_state.dst);
+
+    // Surface-local size the buffer covers before the destination scaling.
+    let surface_size = match (src, buffer_size) {
+        (Some(src), _) => (src.size.w, src.size.h),
+        (None, Some((width, height))) => {
+            // A rotating transform swaps the axes between the two spaces.
+            let (width, height) = match transform {
+                Transform::_90 | Transform::_270 | Transform::Flipped90 | Transform::Flipped270 => {
+                    (height, width)
+                },
+                _ => (width, height),
+            };
+            let scale = f64::from(buffer_scale.max(1));
+            (f64::from(width) / scale, f64::from(height) / scale)
+        },
+        // Nothing to scale against.
+        (None, None) => return rect.to_buffer(buffer_scale, transform, &rect.size),
+    };
+
+    let (scale_w, scale_h) = match dst {
+        Some(dst) if dst.w > 0 && dst.h > 0 => (
+            surface_size.0 / f64::from(dst.w),
+            surface_size.1 / f64::from(dst.h),
+        ),
+        _ => (1.0, 1.0),
+    };
+    let (offset_x, offset_y) = src.map_or((0.0, 0.0), |src| (src.loc.x, src.loc.y));
+
+    let rect = rect.to_f64();
+    let unviewported = Rectangle::new(
+        Point::from((
+            rect.loc.x * scale_w + offset_x,
+            rect.loc.y * scale_h + offset_y,
+        )),
+        Size::from((rect.size.w * scale_w, rect.size.h * scale_h)),
+    );
+
+    // Round outwards: too much damage costs a repaint, too little leaves stale
+    // pixels.
+    let area = Size::from((surface_size.0.ceil() as i32, surface_size.1.ceil() as i32));
+    unviewported
+        .to_i32_up::<i32>()
+        .to_buffer(buffer_scale, transform, &area)
 }

--- a/src/server/client_handlers.rs
+++ b/src/server/client_handlers.rs
@@ -18,6 +18,7 @@ use std::collections::hash_map::Entry;
 use std::fs::File;
 use std::io::Read;
 use std::io::Write;
+use std::mem;
 use std::os::fd::AsFd;
 use std::thread;
 
@@ -161,7 +162,7 @@ impl WprsServerState {
                     // and get data_device events instead. To prevent dropping early, we shouldn't release
                     // these keys yet.
                     if self.dnd_source.is_none() {
-                        let pressed_buttons: HashSet<u32> = self.pressed_buttons.drain().collect();
+                        let pressed_buttons: HashSet<u32> = mem::take(&mut self.pressed_buttons);
                         for button in pressed_buttons {
                             debug!("releasing button {}", button);
                             pointer.button(
@@ -760,7 +761,7 @@ impl WprsServerState {
                             time,
                         },
                     );
-                    let pressed_buttons: HashSet<u32> = self.pressed_buttons.drain().collect();
+                    let pressed_buttons: HashSet<u32> = mem::take(&mut self.pressed_buttons);
                     for button in pressed_buttons {
                         debug!("releasing button {}", button);
                         pointer.button(

--- a/src/server/smithay_handlers.rs
+++ b/src/server/smithay_handlers.rs
@@ -58,9 +58,14 @@ use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::Client;
 use smithay::reexports::wayland_server::Resource;
 use smithay::reexports::wayland_server::WEnum;
+use smithay::utils::Buffer as BufferCoords;
 use smithay::utils::Logical;
 use smithay::utils::Point;
+use smithay::utils::Point as SmithayPoint;
+use smithay::utils::Rectangle as SmithayRectangle;
 use smithay::utils::Serial;
+use smithay::utils::Size as SmithaySize;
+use smithay::utils::Transform as SmithayTransform;
 use smithay::wayland::buffer::BufferHandler;
 use smithay::wayland::compositor;
 use smithay::wayland::compositor::BufferAssignment as SmithayBufferAssignment;
@@ -118,6 +123,7 @@ use crate::serialization::wayland::SurfaceRequest;
 use crate::serialization::wayland::SurfaceRequestPayload;
 use crate::serialization::wayland::SurfaceState;
 use crate::serialization::wayland::Transform;
+use crate::serialization::wayland::ViewportState;
 use crate::serialization::wayland::WlSurfaceId;
 use crate::serialization::xdg_shell::DecorationMode;
 use crate::serialization::xdg_shell::Move;
@@ -680,6 +686,67 @@ pub fn set_viewport_state(viewport_state: &ViewportCachedState, surface_state: &
     surface_state.viewport_state = Some(viewport_state.into());
 }
 
+/// Convert a damage rectangle from surface coordinates to buffer coordinates.
+///
+/// The viewport is part of this mapping, not just buffer_scale: chromium leaves
+/// buffer_scale at 1 and scales entirely through the viewport, so using
+/// buffer_scale alone makes this the identity and the damage then covers only
+/// the top-left corner of the buffer.
+fn surface_damage_to_buffer(
+    rect: SmithayRectangle<i32, Logical>,
+    buffer_scale: i32,
+    transform: SmithayTransform,
+    viewport_state: Option<&ViewportState>,
+    buffer_size: Option<(i32, i32)>,
+) -> SmithayRectangle<i32, BufferCoords> {
+    let src = viewport_state.and_then(|viewport_state| viewport_state.src);
+    let dst = viewport_state.and_then(|viewport_state| viewport_state.dst);
+
+    // Surface-local size the buffer covers before the destination scaling.
+    let surface_size = match (src, buffer_size) {
+        (Some(src), _) => (src.size.w, src.size.h),
+        (None, Some((width, height))) => {
+            // A rotating transform swaps the axes between the two spaces.
+            let (width, height) = match transform {
+                SmithayTransform::_90
+                | SmithayTransform::_270
+                | SmithayTransform::Flipped90
+                | SmithayTransform::Flipped270 => (height, width),
+                _ => (width, height),
+            };
+            let scale = f64::from(buffer_scale.max(1));
+            (f64::from(width) / scale, f64::from(height) / scale)
+        },
+        // Nothing to scale against.
+        (None, None) => return rect.to_buffer(buffer_scale, transform, &rect.size),
+    };
+
+    let (scale_w, scale_h) = match dst {
+        Some(dst) if dst.w > 0 && dst.h > 0 => (
+            surface_size.0 / f64::from(dst.w),
+            surface_size.1 / f64::from(dst.h),
+        ),
+        _ => (1.0, 1.0),
+    };
+    let (offset_x, offset_y) = src.map_or((0.0, 0.0), |src| (src.loc.x, src.loc.y));
+
+    let rect = rect.to_f64();
+    let unviewported = SmithayRectangle::new(
+        SmithayPoint::from((
+            rect.loc.x * scale_w + offset_x,
+            rect.loc.y * scale_h + offset_y,
+        )),
+        SmithaySize::from((rect.size.w * scale_w, rect.size.h * scale_h)),
+    );
+
+    // Round outwards: too much damage costs a repaint, too little leaves stale
+    // pixels.
+    let area = SmithaySize::from((surface_size.0.ceil() as i32, surface_size.1.ceil() as i32));
+    unviewported
+        .to_i32_up::<i32>()
+        .to_buffer(buffer_scale, transform, &area)
+}
+
 #[instrument(skip_all, level = "debug")]
 pub fn set_xdg_surface_attributes(surface_data: &SurfaceData, surface_state: &mut SurfaceState) {
     if surface_data.cached_state.has::<SurfaceCachedState>() {
@@ -879,17 +946,24 @@ pub fn commit_impl(
         },
     }
 
+    let buffer_size = surface_state
+        .buffer
+        .as_ref()
+        .and_then(BufferAssignment::as_new)
+        .map(|buffer| (buffer.metadata.width, buffer.metadata.height));
     let damage = mem::take(&mut surface_attributes.damage)
         .iter()
         .map(|damage| match damage {
             Damage::Buffer(rect) => *rect,
-            Damage::Surface(rect) => rect.to_buffer(
+            Damage::Surface(rect) => surface_damage_to_buffer(
+                *rect,
                 surface_state.buffer_scale,
                 surface_state
                     .buffer_transform
                     .unwrap_or(Transform::Normal)
                     .into(),
-                &rect.size,
+                surface_state.viewport_state.as_ref(),
+                buffer_size,
             ),
         })
         .map(Into::into)

--- a/src/server/smithay_handlers.rs
+++ b/src/server/smithay_handlers.rs
@@ -58,14 +58,9 @@ use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::reexports::wayland_server::Client;
 use smithay::reexports::wayland_server::Resource;
 use smithay::reexports::wayland_server::WEnum;
-use smithay::utils::Buffer as BufferCoords;
 use smithay::utils::Logical;
 use smithay::utils::Point;
-use smithay::utils::Point as SmithayPoint;
-use smithay::utils::Rectangle as SmithayRectangle;
 use smithay::utils::Serial;
-use smithay::utils::Size as SmithaySize;
-use smithay::utils::Transform as SmithayTransform;
 use smithay::wayland::buffer::BufferHandler;
 use smithay::wayland::compositor;
 use smithay::wayland::compositor::BufferAssignment as SmithayBufferAssignment;
@@ -123,7 +118,6 @@ use crate::serialization::wayland::SurfaceRequest;
 use crate::serialization::wayland::SurfaceRequestPayload;
 use crate::serialization::wayland::SurfaceState;
 use crate::serialization::wayland::Transform;
-use crate::serialization::wayland::ViewportState;
 use crate::serialization::wayland::WlSurfaceId;
 use crate::serialization::xdg_shell::DecorationMode;
 use crate::serialization::xdg_shell::Move;
@@ -686,67 +680,6 @@ pub fn set_viewport_state(viewport_state: &ViewportCachedState, surface_state: &
     surface_state.viewport_state = Some(viewport_state.into());
 }
 
-/// Convert a damage rectangle from surface coordinates to buffer coordinates.
-///
-/// The viewport is part of this mapping, not just buffer_scale: chromium leaves
-/// buffer_scale at 1 and scales entirely through the viewport, so using
-/// buffer_scale alone makes this the identity and the damage then covers only
-/// the top-left corner of the buffer.
-fn surface_damage_to_buffer(
-    rect: SmithayRectangle<i32, Logical>,
-    buffer_scale: i32,
-    transform: SmithayTransform,
-    viewport_state: Option<&ViewportState>,
-    buffer_size: Option<(i32, i32)>,
-) -> SmithayRectangle<i32, BufferCoords> {
-    let src = viewport_state.and_then(|viewport_state| viewport_state.src);
-    let dst = viewport_state.and_then(|viewport_state| viewport_state.dst);
-
-    // Surface-local size the buffer covers before the destination scaling.
-    let surface_size = match (src, buffer_size) {
-        (Some(src), _) => (src.size.w, src.size.h),
-        (None, Some((width, height))) => {
-            // A rotating transform swaps the axes between the two spaces.
-            let (width, height) = match transform {
-                SmithayTransform::_90
-                | SmithayTransform::_270
-                | SmithayTransform::Flipped90
-                | SmithayTransform::Flipped270 => (height, width),
-                _ => (width, height),
-            };
-            let scale = f64::from(buffer_scale.max(1));
-            (f64::from(width) / scale, f64::from(height) / scale)
-        },
-        // Nothing to scale against.
-        (None, None) => return rect.to_buffer(buffer_scale, transform, &rect.size),
-    };
-
-    let (scale_w, scale_h) = match dst {
-        Some(dst) if dst.w > 0 && dst.h > 0 => (
-            surface_size.0 / f64::from(dst.w),
-            surface_size.1 / f64::from(dst.h),
-        ),
-        _ => (1.0, 1.0),
-    };
-    let (offset_x, offset_y) = src.map_or((0.0, 0.0), |src| (src.loc.x, src.loc.y));
-
-    let rect = rect.to_f64();
-    let unviewported = SmithayRectangle::new(
-        SmithayPoint::from((
-            rect.loc.x * scale_w + offset_x,
-            rect.loc.y * scale_h + offset_y,
-        )),
-        SmithaySize::from((rect.size.w * scale_w, rect.size.h * scale_h)),
-    );
-
-    // Round outwards: too much damage costs a repaint, too little leaves stale
-    // pixels.
-    let area = SmithaySize::from((surface_size.0.ceil() as i32, surface_size.1.ceil() as i32));
-    unviewported
-        .to_i32_up::<i32>()
-        .to_buffer(buffer_scale, transform, &area)
-}
-
 #[instrument(skip_all, level = "debug")]
 pub fn set_xdg_surface_attributes(surface_data: &SurfaceData, surface_state: &mut SurfaceState) {
     if surface_data.cached_state.has::<SurfaceCachedState>() {
@@ -955,7 +888,7 @@ pub fn commit_impl(
         .iter()
         .map(|damage| match damage {
             Damage::Buffer(rect) => *rect,
-            Damage::Surface(rect) => surface_damage_to_buffer(
+            Damage::Surface(rect) => compositor_utils::surface_damage_to_buffer(
                 *rect,
                 surface_state.buffer_scale,
                 surface_state

--- a/src/sharding_compression.rs
+++ b/src/sharding_compression.rs
@@ -67,7 +67,7 @@ impl fmt::Debug for CompressedShard {
         f.debug_struct("CompressedShard")
             .field("idx", &self.idx)
             .field("compression", &self.compression)
-            .field("data", &format_args!("Vec<u8>[{:?}]", &self.data.len()))
+            .field("data", &format_args!("Vec<u8>[{:?}]", self.data.len()))
             .finish()
     }
 }

--- a/src/xwayland_xdg_shell/compositor.rs
+++ b/src/xwayland_xdg_shell/compositor.rs
@@ -593,14 +593,22 @@ pub fn commit_inner(
         decorated_subsurface.draw();
     }
 
+    let buffer_size = xwayland_surface
+        .buffer
+        .as_ref()
+        .map(|buffer| (buffer.metadata.width, buffer.metadata.height));
     let damage = &mut mem::take(&mut surface_attributes.damage)
         .iter()
         .map(|damage| match damage {
             Damage::Buffer(rect) => *rect,
-            Damage::Surface(rect) => rect.to_buffer(
+            // Xwayland surfaces have no viewport, but the conversion still
+            // needs the surface size rather than the damage rect's own size.
+            Damage::Surface(rect) => compositor_utils::surface_damage_to_buffer(
+                *rect,
                 surface_attributes.buffer_scale,
                 surface_attributes.buffer_transform.into(),
-                &rect.size,
+                None,
+                buffer_size,
             ),
         })
         .map(Into::into)


### PR DESCRIPTION
Observed with chromium-based apps (google-chrome, obsidian) run with
`--ozone-platform=wayland`, on a laptop with a built-in screen and an external
display. Only the top-left corner of the window repaints. The rest goes stale
until a resize forces a full redraw.

This is not scale-dependent: setting both displays to integer scales changes
nothing.

`wl_surface.damage` is in surface coordinates, and wprsd converted it to buffer
coordinates using `buffer_scale` alone. Chromium leaves `buffer_scale` at 1 and
scales through `wp_viewport` instead, so the conversion is the identity and the
damage comes out at surface size against a larger buffer.

From `WAYLAND_DEBUG` traces of chromium against wprsd, and wprsc against mutter:

| | |
|---|---|
| buffer | 3466x1458 (stride 13864) |
| `wp_viewport.set_destination` | 1733x729 |
| `set_buffer_scale` | never called (default 1) |
| max damage wprsc forwarded | x+w = 1733, y+h = 857 |

1733 is half of 3466, so mutter repainted a quarter of the surface.

`surface_damage_to_buffer` now undoes the viewport's destination scaling and
source offset before applying `buffer_scale` and `buffer_transform`, and rounds
outward so damage is never too small. It also fixes the `area` passed to
`to_buffer`, which was the damage rect's own size instead of the surface size,
wrong for rotated and flipped transforms.

The same conversion existed in xwayland-xdg-shell, so the helper moved to
`compositor_utils` and both paths use it. Xwayland surfaces have no viewport, so
there it only corrects the `area`.

Manual verification:
[`full-damage-flag`](https://github.com/jon-dez/wprs/tree/full-damage-flag) adds
`--full-damage` to wprsc, which discards received damage and damages the whole
surface every frame. On unpatched wprs, `--full-damage=true` makes the problem
disappear, isolating it to damage rather than buffer contents. Not part of this
PR.

First commit is #155, included so the pre-commit hook passes here.

Tested with `cargo test --all-features`, `cargo +nightly cranky --all-targets --
-D warnings`, `cargo +nightly fmt -- --check`, `cargo +nightly miri test`.